### PR TITLE
Add ability to use row field as link

### DIFF
--- a/taack-ui/src/main/groovy/taack/ui/base/table/IUiTableVisitor.groovy
+++ b/taack-ui/src/main/groovy/taack/ui/base/table/IUiTableVisitor.groovy
@@ -40,17 +40,17 @@ interface IUiTableVisitor {
 
     void visitRowColumn(Integer colSpan, Integer rowSpan)
 
-    void visitRowField(FieldInfo fieldInfo, String format, final Style style)
+    void visitRowField(FieldInfo fieldInfo, String format, final Style style, final String controller, final String action, final Long id)
 
-    void visitRowField(GetMethodReturn fieldInfo, final Style style)
+    void visitRowField(GetMethodReturn fieldInfo, final Style style, final String controller, final String action, final Long id)
 
-    void visitRowField(String value, final Style style)
+    void visitRowField(String value, final Style style, final String controller, final String action, final Long id)
 
-    void visitRowField(Long value, final Style style)
+    void visitRowField(Long value, final Style style, final String controller, final String action, final Long id)
 
-    void visitRowField(BigDecimal value, String format, final Style style)
+    void visitRowField(BigDecimal value, String format, final Style style, final String controller, final String action, final Long id)
 
-    void visitRowField(Date value, String format, final Style style)
+    void visitRowField(Date value, String format, final Style style, final String controller, final String action, final Long id)
 
     void visitRowLink(String i18n, ActionIcon actionIcon, String controller, String action, Long id, Map<String, ?> params, Boolean isAjax)
 
@@ -68,11 +68,11 @@ interface IUiTableVisitor {
 
     void visitRowGroupFooter(String content)
 
-    void visitRowField(Map value, Style style)
+    void visitRowField(Map value, Style style, String controller, String action, Long id)
 
-    void visitRowField(EnumStyle value, Style style)
+    void visitRowField(EnumStyle value, Style style, String controller, String action, Long id)
 
-    void visitRowField(BigDecimal value, NumberFormat numberFormat, Style style)
+    void visitRowField(BigDecimal value, NumberFormat numberFormat, Style style, String controller, String action, Long id)
 
     void visitColumn(Integer colSpan, Integer rowSpan)
 

--- a/taack-ui/src/main/groovy/taack/ui/base/table/RowColumnFieldSpec.groovy
+++ b/taack-ui/src/main/groovy/taack/ui/base/table/RowColumnFieldSpec.groovy
@@ -26,40 +26,40 @@ class RowColumnFieldSpec {
         this.tableVisitor = tableVisitor
     }
 
-    void rowField(final FieldInfo field, final String format = null, final Style style = null) {
-        tableVisitor.visitRowField(field, format, style)
+    void rowField(final FieldInfo field, final String format = null, final Style style = null, final MethodClosure action = null, final Long id = null) {
+        tableVisitor.visitRowField(field, format, style, Utils.getControllerName(action), action.method, id)
     }
 
-    void rowField(final GetMethodReturn field, final Style style = null) {
-        tableVisitor.visitRowField(field, style)
+    void rowField(final GetMethodReturn field, final Style style = null, final MethodClosure action = null, final Long id = null) {
+        tableVisitor.visitRowField(field, style, action ? Utils.getControllerName(action) : null, action?.method, id)
     }
 
-    void rowField(final String value, final Style style = null) {
-        tableVisitor.visitRowField(value, style)
+    void rowField(final String value, final Style style = null, final MethodClosure action = null, final Long id = null) {
+        tableVisitor.visitRowField(value, style, action ? Utils.getControllerName(action) : null, action?.method, id)
     }
 
-    void rowField(final Long value, final Style style = null) {
-        tableVisitor.visitRowField(value, style)
+    void rowField(final Long value, final Style style = null, final MethodClosure action = null, final Long id = null) {
+        tableVisitor.visitRowField(value, style, action ? Utils.getControllerName(action) : null, action?.method, id)
     }
 
-    void rowField(final BigDecimal value, final Style style = null) {
-        tableVisitor.visitRowField(value, null as NumberFormat, style)
+    void rowField(final BigDecimal value, final Style style = null, final MethodClosure action = null, final Long id = null) {
+        tableVisitor.visitRowField(value, null as NumberFormat, style, action ? Utils.getControllerName(action) : null, action?.method, id)
     }
 
-    void rowField(final BigDecimal value, final NumberFormat format, final Style style = null) {
-        tableVisitor.visitRowField(value, format, style)
+    void rowField(final BigDecimal value, final NumberFormat format, final Style style = null, final MethodClosure action = null, final Long id = null) {
+        tableVisitor.visitRowField(value, format, style, action ? Utils.getControllerName(action) : null, action?.method, id)
     }
 
-    void rowField(final Map value, final Style style = null) {
-        tableVisitor.visitRowField(value, style)
+    void rowField(final Map value, final Style style = null, final MethodClosure action = null, final Long id = null) {
+        tableVisitor.visitRowField(value, style, action ? Utils.getControllerName(action) : null, action?.method, id)
     }
 
-    void rowField(final EnumStyle value, final Style style = null) {
-        tableVisitor.visitRowField(value, style)
+    void rowField(final EnumStyle value, final Style style = null, final MethodClosure action = null, final Long id = null) {
+        tableVisitor.visitRowField(value, style, action ? Utils.getControllerName(action) : null, action?.method, id)
     }
 
-    void rowField(final Date value, final String format = null, final Style style = null) {
-        tableVisitor.visitRowField(value, format, style)
+    void rowField(final Date value, final String format = null, final Style style = null, final MethodClosure action = null, final Long id = null) {
+        tableVisitor.visitRowField(value, format, style, action ? Utils.getControllerName(action) : null, action?.method, id)
     }
 
     void rowLink(final String i18n, final ActionIcon icon, final String controller, final String action, final Long id = null, final Boolean isAjax = true) {

--- a/taack-ui/src/main/groovy/taack/ui/base/table/RowColumnFieldSpec.groovy
+++ b/taack-ui/src/main/groovy/taack/ui/base/table/RowColumnFieldSpec.groovy
@@ -27,39 +27,39 @@ class RowColumnFieldSpec {
     }
 
     void rowField(final FieldInfo field, final String format = null, final Style style = null, final MethodClosure action = null, final Long id = null) {
-        tableVisitor.visitRowField(field, format, style, Utils.getControllerName(action), action.method, id)
+        tableVisitor.visitRowField(field, format, style, action && taackUiEnablerService.hasAccess(action, id) ? Utils.getControllerName(action) : null, action?.method, id)
     }
 
     void rowField(final GetMethodReturn field, final Style style = null, final MethodClosure action = null, final Long id = null) {
-        tableVisitor.visitRowField(field, style, action ? Utils.getControllerName(action) : null, action?.method, id)
+        tableVisitor.visitRowField(field, style, action && taackUiEnablerService.hasAccess(action, id) ? Utils.getControllerName(action) : null, action?.method, id)
     }
 
     void rowField(final String value, final Style style = null, final MethodClosure action = null, final Long id = null) {
-        tableVisitor.visitRowField(value, style, action ? Utils.getControllerName(action) : null, action?.method, id)
+        tableVisitor.visitRowField(value, style, action && taackUiEnablerService.hasAccess(action, id) ? Utils.getControllerName(action) : null, action?.method, id)
     }
 
     void rowField(final Long value, final Style style = null, final MethodClosure action = null, final Long id = null) {
-        tableVisitor.visitRowField(value, style, action ? Utils.getControllerName(action) : null, action?.method, id)
+        tableVisitor.visitRowField(value, style, action && taackUiEnablerService.hasAccess(action, id) ? Utils.getControllerName(action) : null, action?.method, id)
     }
 
     void rowField(final BigDecimal value, final Style style = null, final MethodClosure action = null, final Long id = null) {
-        tableVisitor.visitRowField(value, null as NumberFormat, style, action ? Utils.getControllerName(action) : null, action?.method, id)
+        tableVisitor.visitRowField(value, null as NumberFormat, style, action && taackUiEnablerService.hasAccess(action, id) ? Utils.getControllerName(action) : null, action?.method, id)
     }
 
     void rowField(final BigDecimal value, final NumberFormat format, final Style style = null, final MethodClosure action = null, final Long id = null) {
-        tableVisitor.visitRowField(value, format, style, action ? Utils.getControllerName(action) : null, action?.method, id)
+        tableVisitor.visitRowField(value, format, style, action && taackUiEnablerService.hasAccess(action, id) ? Utils.getControllerName(action) : null, action?.method, id)
     }
 
     void rowField(final Map value, final Style style = null, final MethodClosure action = null, final Long id = null) {
-        tableVisitor.visitRowField(value, style, action ? Utils.getControllerName(action) : null, action?.method, id)
+        tableVisitor.visitRowField(value, style, action && taackUiEnablerService.hasAccess(action, id)  ? Utils.getControllerName(action) : null, action?.method, id)
     }
 
     void rowField(final EnumStyle value, final Style style = null, final MethodClosure action = null, final Long id = null) {
-        tableVisitor.visitRowField(value, style, action ? Utils.getControllerName(action) : null, action?.method, id)
+        tableVisitor.visitRowField(value, style, action && taackUiEnablerService.hasAccess(action, id)  ? Utils.getControllerName(action) : null, action?.method, id)
     }
 
     void rowField(final Date value, final String format = null, final Style style = null, final MethodClosure action = null, final Long id = null) {
-        tableVisitor.visitRowField(value, format, style, action ? Utils.getControllerName(action) : null, action?.method, id)
+        tableVisitor.visitRowField(value, format, style, action && taackUiEnablerService.hasAccess(action, id) ? Utils.getControllerName(action) : null, action?.method, id)
     }
 
     void rowLink(final String i18n, final ActionIcon icon, final String controller, final String action, final Long id = null, final Boolean isAjax = true) {

--- a/taack-ui/src/main/groovy/taack/ui/base/table/UiTableVisitorImpl.groovy
+++ b/taack-ui/src/main/groovy/taack/ui/base/table/UiTableVisitorImpl.groovy
@@ -75,32 +75,32 @@ class UiTableVisitorImpl implements IUiTableVisitor {
     }
 
     @Override
-    void visitRowField(FieldInfo fieldInfo, String format, Style style) {
+    void visitRowField(FieldInfo fieldInfo, String format, Style style, String controller, String action, Long id) {
 
     }
 
     @Override
-    void visitRowField(GetMethodReturn fieldInfo, Style style) {
+    void visitRowField(GetMethodReturn fieldInfo, Style style, String controller, String action, Long id) {
 
     }
 
     @Override
-    void visitRowField(String value, Style style) {
+    void visitRowField(String value, Style style, String controller, String action, Long id) {
 
     }
 
     @Override
-    void visitRowField(Long value, Style style) {
+    void visitRowField(Long value, Style style, String controller, String action, Long id) {
 
     }
 
     @Override
-    void visitRowField(BigDecimal value, String format, Style style) {
+    void visitRowField(BigDecimal value, String format, Style style, String controller, String action, Long id) {
 
     }
 
     @Override
-    void visitRowField(Date value, String format, Style style) {
+    void visitRowField(Date value, String format, Style style, String controller, String action, Long id) {
 
     }
 
@@ -140,17 +140,17 @@ class UiTableVisitorImpl implements IUiTableVisitor {
     }
 
     @Override
-    void visitRowField(Map value, Style style) {
+    void visitRowField(Map value, Style style, String controller, String action, Long id) {
 
     }
 
     @Override
-    void visitRowField(EnumStyle value, Style style) {
+    void visitRowField(EnumStyle value, Style style, String controller, String action, Long id) {
 
     }
 
     @Override
-    void visitRowField(BigDecimal value, NumberFormat numberFormat, Style style) {
+    void visitRowField(BigDecimal value, NumberFormat numberFormat, Style style, String controller, String action, Long id) {
 
     }
 

--- a/taack-ui/src/main/groovy/taack/ui/dump/RawCsvTableDump.groovy
+++ b/taack-ui/src/main/groovy/taack/ui/dump/RawCsvTableDump.groovy
@@ -24,12 +24,12 @@ final class RawCsvTableDump extends UiTableVisitorImpl {
     }
 
     @Override
-    void visitRowField(EnumStyle value, Style style) {
+    void visitRowField(EnumStyle value, Style style, String controller = null, String action = null, Long id = null) {
         out << (value?.name?:"") + sep
     }
 
     @Override
-    void visitRowField(BigDecimal value, NumberFormat numberFormat, Style style) {
+    void visitRowField(BigDecimal value, NumberFormat numberFormat, Style style, String controller = null, String action = null, Long id = null) {
         out << (value?.toString()?:"") + sep
     }
 
@@ -65,42 +65,42 @@ final class RawCsvTableDump extends UiTableVisitorImpl {
     }
 
     @Override
-    void visitRowField(final FieldInfo fieldInfo, final String format = null, final Style style) {
+    void visitRowField(final FieldInfo fieldInfo, final String format = null, final Style style, final String controller = null, final String action = null, final Long id = null) {
         switch (fieldInfo.fieldConstraint.field.type) {
             case Long:
             case Integer:
-                visitRowField((Long) fieldInfo.value, style)
+                visitRowField((Long) fieldInfo.value, style, controller, action, id)
                 break
             case Double:
             case Float:
             case BigDecimal:
-                visitRowField((BigDecimal) fieldInfo.value, style)
+                visitRowField((BigDecimal) fieldInfo.value, format, style, controller, action, id)
                 break
             case Date:
-                visitRowField((Date) fieldInfo.value, style)
+                visitRowField((Date) fieldInfo.value, format, style, controller, action, id)
                 break
             default:
-                visitRowField((String) fieldInfo.value, style)
+                visitRowField((String) fieldInfo.value, style, controller, action, id)
         }
     }
 
     @Override
-    void visitRowField(final GetMethodReturn fieldInfo, final Style style) {
+    void visitRowField(final GetMethodReturn fieldInfo, final Style style, final String controller = null, final String action = null, final Long id = null) {
         switch (fieldInfo.getMethod().returnType) {
             case Long:
             case Integer:
-                visitRowField((Long) fieldInfo.value, style)
+                visitRowField((Long) fieldInfo.value, style, controller, action, id)
                 break
             case Double:
             case Float:
             case BigDecimal:
-                visitRowField((BigDecimal) fieldInfo.value, style)
+                visitRowField((BigDecimal) fieldInfo.value, (String) null, style, controller, action, id)
                 break
             case Date:
-                visitRowField((Date) fieldInfo.value, style)
+                visitRowField((Date) fieldInfo.value, null, style, controller, action, id)
                 break
             default:
-                visitRowField((String) fieldInfo.value, style)
+                visitRowField((String) fieldInfo.value, style, controller, action, id)
         }
     }
 
@@ -109,23 +109,23 @@ final class RawCsvTableDump extends UiTableVisitorImpl {
     }
 
     @Override
-    void visitRowField(final String value, final Style style) {
+    void visitRowField(final String value, final Style style, final String controller = null, final String action = null, final Long id = null) {
         out << surroundCell(value)
     }
 
     @Override
-    void visitRowField(final Long value, final Style style) {
+    void visitRowField(final Long value, final Style style, final String controller = null, final String action = null, final Long id = null) {
         out << surroundCell(value?.toString())
     }
 
     @Override
-    void visitRowField(final BigDecimal value, final String format = null, final Style style) {
+    void visitRowField(final BigDecimal value, final String format = null, final Style style, final String controller = null, final String action = null, final Long id = null) {
         DecimalFormat df = new DecimalFormat(format ?: "#,###.00")
         out << surroundCell(df.format(value))
     }
 
     @Override
-    void visitRowField(final Date value, final String format = null, final Style style) {
+    void visitRowField(final Date value, final String format = null, final Style style, final String controller = null, final String action = null, final Long id = null) {
         SimpleDateFormat sdf = new SimpleDateFormat(format ?: "yyyy-MM-dd")
         out << surroundCell(sdf.format(value))
     }

--- a/taack-ui/src/main/groovy/taack/ui/dump/RawHtmlTableDump.groovy
+++ b/taack-ui/src/main/groovy/taack/ui/dump/RawHtmlTableDump.groovy
@@ -199,110 +199,112 @@ final class RawHtmlTableDump implements IUiTableVisitor {
     }
 
     @Override
-    void visitRowField(final FieldInfo fieldInfo, final String format = null, final Style style) {
+    void visitRowField(final FieldInfo fieldInfo, final String format = null, final Style style, final String controller = null, final String action = null, final Long id = null) {
         switch (fieldInfo.fieldConstraint.field.type) {
             case Long:
             case Integer:
-                visitRowField((Long) fieldInfo.value, style)
+                visitRowField((Long) fieldInfo.value, style, controller, action, id)
                 break
             case Double:
             case Float:
             case BigDecimal:
-                visitRowField((BigDecimal) fieldInfo.value, style)
+                visitRowField((BigDecimal) fieldInfo.value, format, style, controller, action, id)
                 break
             case Date:
-                visitRowField((Date) fieldInfo.value, style)
+                visitRowField((Date) fieldInfo.value, format, style, controller, action, id)
                 break
             default:
-                visitRowField((String) fieldInfo.value, style)
+                visitRowField((String) fieldInfo.value, style, controller, action, id)
         }
     }
 
     @Override
-    void visitRowField(final GetMethodReturn fieldInfo, final Style style) {
+    void visitRowField(final GetMethodReturn fieldInfo, final Style style, final String controller = null, final String action = null, final Long id = null) {
         switch (fieldInfo.getMethod().returnType) {
             case Long:
             case Integer:
-                visitRowField((Long) fieldInfo.value, style)
+                visitRowField((Long) fieldInfo.value, style, controller, action, id)
                 break
             case Double:
             case Float:
             case BigDecimal:
-                visitRowField((BigDecimal) fieldInfo.value, style)
+                visitRowField((BigDecimal) fieldInfo.value, (String) null, style, controller, action, id)
                 break
             case Date:
-                visitRowField((Date) fieldInfo.value, style)
+                visitRowField((Date) fieldInfo.value, null, style, controller, action, id)
                 break
             default:
-                visitRowField((String) fieldInfo.value, style)
+                visitRowField((String) fieldInfo.value, style, controller, action, id)
         }
     }
 
-    private static String surroundCell(final String cell, final Style style = null) {
+    private static String surroundCell(final String cell, final Style style = null, final String url = null) {
         if (style) {
             if (!cell || cell.empty) return ""
             return """
-                <div class="${style.cssClassesString ?: ''}" style="${style.cssStyleString ?: ''}">${cell ?: ''}</div>
+                <div class="${style.cssClassesString ?: ''}" style="${style.cssStyleString ?: ''}">
+                    ${url ? "<a class='link' href='${url}'>${cell ?: ''}</a>" : "${cell ?: ''}"}
+                </div>
             """
-        } else return "${cell && !cell.empty ? cell + "<br>" : ''}"
+        } else return "${cell && !cell.empty ? "${url ? "<a class='link' href='${url}'>${cell ?: ''}</a>" : "${cell}"} <br>" : ''}"
     }
 
     @Override
-    void visitRowField(final String value, final Style style) {
+    void visitRowField(final String value, final Style style, final String controller = null, final String action = null, final Long id = null) {
         fieldHeader()
-        out << surroundCell(value, style)
+        out << surroundCell(value, style, controller ? parameter.urlMapped(controller, action, id) : null)
         fieldFooter()
     }
 
     @Override
-    void visitRowField(final Long value, final Style style) {
+    void visitRowField(final Long value, final Style style, final String controller = null, final String action = null, final Long id = null) {
         fieldHeader()
         out << surroundCell(value?.toString(), style)
         fieldFooter()
     }
 
     @Override
-    void visitRowField(final BigDecimal value, final String format = null, final Style style) {
+    void visitRowField(final BigDecimal value, final String format = null, final Style style, final String controller = null, final String action = null, final Long id = null) {
         DecimalFormat df = new DecimalFormat(format ?: "#,###.00")
         fieldHeader()
-        if (value) out << surroundCell(df.format(value), style ?: new Style(null, "text-align: right;"))
+        if (value) out << surroundCell(df.format(value), style ?: new Style(null, "text-align: right;"), controller ? parameter.urlMapped(controller, action, id) : null)
         fieldFooter()
     }
 
     @Override
-    void visitRowField(final Date value, final String format = null, final Style style) {
+    void visitRowField(final Date value, final String format = null, final Style style, final String controller = null, final String action = null, final Long id = null) {
         SimpleDateFormat sdf = new SimpleDateFormat(format ?: "yyyy-MM-dd")
         fieldHeader()
-        out << surroundCell(value ? sdf.format(value) : "", style)
+        out << surroundCell(value ? sdf.format(value) : "", style, controller ? parameter.urlMapped(controller, action, id) : null)
         fieldFooter()
     }
 
     @Override
-    void visitRowField(Map value, Style style) {
+    void visitRowField(Map value, Style style, String controller = null, String action = null, Long id = null) {
         String display = value?.entrySet()?.findAll {
             it.value != null
         }?.collect { "${it.key}: ${it.value}" }?.join(', ')
         fieldHeader()
-        out << surroundCell(display ?: "")
+        out << surroundCell(display ?: "", null, controller ? parameter.urlMapped(controller, action, id) : null)
         fieldFooter()
     }
 
     @Override
-    void visitRowField(EnumStyle value, Style style) {
+    void visitRowField(EnumStyle value, Style style, String controller = null, String action = null, Long id = null) {
         if (value?.getStyle()) {
             if (style) style = value.getStyle() + style
             else style = value.getStyle()
         }
         fieldHeader()
-        out << surroundCell(value?.getName(), style)
+        out << surroundCell(value?.getName(), style, controller ? parameter.urlMapped(controller, action, id) : null)
         fieldFooter()
     }
 
     @Override
-    void visitRowField(BigDecimal value, NumberFormat numberFormat, Style style) {
+    void visitRowField(BigDecimal value, NumberFormat numberFormat, Style style, String controller = null, String action = null, Long id = null) {
         if (!numberFormat) numberFormat = parameter.nf
         fieldHeader()
-        if (value) out << surroundCell(numberFormat.format(value), style ?: new Style(null, "text-align: right;"))
+        if (value) out << surroundCell(numberFormat.format(value), style ?: new Style(null, "text-align: right;"), controller ? parameter.urlMapped(controller, action, id) : null)
         fieldFooter()
     }
 

--- a/taack-ui/src/main/groovy/taack/ui/mail/dump/RawHtmlTableDump.groovy
+++ b/taack-ui/src/main/groovy/taack/ui/mail/dump/RawHtmlTableDump.groovy
@@ -143,46 +143,46 @@ final class RawHtmlTableDump implements IUiTableVisitor {
     }
 
     @Override
-    void visitRowField(final FieldInfo fieldInfo, final String format = null, final Style style) {
+    void visitRowField(final FieldInfo fieldInfo, final String format = null, final Style style, String controller = null, String action = null, Long id = null) {
         switch (fieldInfo.fieldConstraint.field.type) {
             case Long:
             case Integer:
-                visitRowField((Long) fieldInfo.value, style)
+                visitRowField((Long) fieldInfo.value, style, controller, action, id)
                 break
             case Double:
             case Float:
             case BigDecimal:
-                visitRowField((BigDecimal) fieldInfo.value, style)
+                visitRowField((BigDecimal) fieldInfo.value, format, style, controller, action, id)
                 break
             case Date:
-                visitRowField((Date) fieldInfo.value, style)
+                visitRowField((Date) fieldInfo.value, format, style, controller, action, id)
                 break
             default:
-                visitRowField((String) fieldInfo.value, style)
+                visitRowField((String) fieldInfo.value, style, controller, action, id)
         }
     }
 
     @Override
-    void visitRowField(final GetMethodReturn fieldInfo, final Style style) {
+    void visitRowField(final GetMethodReturn fieldInfo, final Style style, String controller = null, String action = null, Long id = null) {
         switch (fieldInfo.getMethod().returnType) {
             case Long:
             case Integer:
-                visitRowField((Long) fieldInfo.value, style)
+                visitRowField((Long) fieldInfo.value, style, controller, action, id)
                 break
             case Double:
             case Float:
             case BigDecimal:
-                visitRowField((BigDecimal) fieldInfo.value, style)
+                visitRowField((BigDecimal) fieldInfo.value, (String) null, style, controller, action, id)
                 break
             case Date:
-                visitRowField((Date) fieldInfo.value, style)
+                visitRowField((Date) fieldInfo.value, null, style, controller, action, id)
                 break
             default:
-                visitRowField((String) fieldInfo.value, style)
+                visitRowField((String) fieldInfo.value, style, controller, action, id)
         }
     }
 
-    private static String surroundCell(final String cell, final Style style = null) {
+    private static String surroundCell(final String cell, final Style style = null, String controller = null, String action = null, Long id = null) {
         if (style) {
             if (!cell || cell.empty) return ""
             return """
@@ -192,29 +192,29 @@ final class RawHtmlTableDump implements IUiTableVisitor {
     }
 
     @Override
-    void visitRowField(final String value, final Style style) {
+    void visitRowField(final String value, final Style style, String controller = null, String action = null, Long id = null) {
         out << surroundCell(value, style)
     }
 
     @Override
-    void visitRowField(final Long value, final Style style) {
+    void visitRowField(final Long value, final Style style, String controller = null, String action = null, Long id = null) {
         out << surroundCell(value?.toString(), style)
     }
 
     @Override
-    void visitRowField(final BigDecimal value, final String format = null, final Style style) {
+    void visitRowField(final BigDecimal value, final String format = null, final Style style, String controller = null, String action = null, Long id = null) {
         DecimalFormat df = new DecimalFormat(format ?: "#,###.00")
         if (value) out << surroundCell(df.format(value), style ?: new Style(null, "text-align: right;"))
     }
 
     @Override
-    void visitRowField(final Date value, final String format = null, final Style style) {
+    void visitRowField(final Date value, final String format = null, final Style style, String controller = null, String action = null, Long id = null) {
         SimpleDateFormat sdf = new SimpleDateFormat(format ?: "yyyy-MM-dd")
         out << surroundCell(value ? sdf.format(value) : "", style)
     }
 
     @Override
-    void visitRowField(Map value, Style style) {
+    void visitRowField(Map value, Style style, String controller = null, String action = null, Long id = null) {
         String display = value.entrySet().findAll {
             it.value != null
         }.collect { "${it.key}: ${it.value}" }.join(', ')
@@ -222,7 +222,7 @@ final class RawHtmlTableDump implements IUiTableVisitor {
     }
 
     @Override
-    void visitRowField(EnumStyle value, Style style) {
+    void visitRowField(EnumStyle value, Style style, String controller = null, String action = null, Long id = null) {
         if (value?.getStyle()) {
             if (style) style = value.getStyle() + style
             else style = value.getStyle()
@@ -231,7 +231,7 @@ final class RawHtmlTableDump implements IUiTableVisitor {
     }
 
     @Override
-    void visitRowField(BigDecimal value, NumberFormat numberFormat, Style style) {
+    void visitRowField(BigDecimal value, NumberFormat numberFormat, Style style, String controller = null, String action = null, Long id = null) {
         if (value) out << surroundCell(numberFormat.format(value), style ?: new Style(null, "text-align: right;"))
     }
 

--- a/taack-ui/src/main/groovy/taack/ui/pdf/dump/RawHtmlTableDump.groovy
+++ b/taack-ui/src/main/groovy/taack/ui/pdf/dump/RawHtmlTableDump.groovy
@@ -148,42 +148,42 @@ final class RawHtmlTableDump implements IUiTableVisitor {
     }
 
     @Override
-    void visitRowField(final FieldInfo fieldInfo, final String format = null, final Style style) {
+    void visitRowField(final FieldInfo fieldInfo, final String format = null, final Style style, final String controller = null, final String action = null, final Long id = null) {
         switch (fieldInfo.fieldConstraint.field.type) {
             case Long:
             case Integer:
-                visitRowField((Long) fieldInfo.value, style)
+                visitRowField((Long) fieldInfo.value, style, controller, action, id)
                 break
             case Double:
             case Float:
             case BigDecimal:
-                visitRowField((BigDecimal) fieldInfo.value, style)
+                visitRowField((BigDecimal) fieldInfo.value, format, style, controller, action, id)
                 break
             case Date:
-                visitRowField((Date) fieldInfo.value, style)
+                visitRowField((Date) fieldInfo.value, format, style, controller, action, id)
                 break
             default:
-                visitRowField((String) fieldInfo.value, style)
+                visitRowField((String) fieldInfo.value, style, controller, action, id)
         }
     }
 
     @Override
-    void visitRowField(final GetMethodReturn fieldInfo, final Style style) {
+    void visitRowField(final GetMethodReturn fieldInfo, final Style style, final String controller = null, final String action = null, final Long id = null) {
         switch (fieldInfo.getMethod().returnType) {
             case Long:
             case Integer:
-                visitRowField((Long) fieldInfo.value, style)
+                visitRowField((Long) fieldInfo.value, style, controller, action, id)
                 break
             case Double:
             case Float:
             case BigDecimal:
-                visitRowField((BigDecimal) fieldInfo.value, style)
+                visitRowField((BigDecimal) fieldInfo.value, (String) null, style, controller, action, id)
                 break
             case Date:
-                visitRowField((Date) fieldInfo.value, style)
+                visitRowField((Date) fieldInfo.value, null, style, controller, action, id)
                 break
             default:
-                visitRowField((String) fieldInfo.value, style)
+                visitRowField((String) fieldInfo.value, style, controller, action, id)
         }
     }
 
@@ -197,29 +197,29 @@ final class RawHtmlTableDump implements IUiTableVisitor {
     }
 
     @Override
-    void visitRowField(final String value, final Style style) {
+    void visitRowField(final String value, final Style style, final String controller = null, final String action = null, final Long id = null) {
         out << surroundCell(value, style)
     }
 
     @Override
-    void visitRowField(final Long value, final Style style) {
+    void visitRowField(final Long value, final Style style, final String controller = null, final String action = null, final Long id = null) {
         out << surroundCell(value?.toString(), style)
     }
 
     @Override
-    void visitRowField(final BigDecimal value, final String format = null, final Style style) {
+    void visitRowField(final BigDecimal value, final String format = null, final Style style, final String controller = null, final String action = null, final Long id = null) {
         DecimalFormat df = new DecimalFormat(format ?: "#,###.00")
         if (value) out << surroundCell(df.format(value), style ?: new Style(null, "text-align: right;"))
     }
 
     @Override
-    void visitRowField(final Date value, final String format = null, final Style style) {
+    void visitRowField(final Date value, final String format = null, final Style style, final String controller = null, final String action = null, final Long id = null) {
         SimpleDateFormat sdf = new SimpleDateFormat(format ?: "yyyy-MM-dd")
         out << surroundCell(value ? sdf.format(value) : "", style)
     }
 
     @Override
-    void visitRowField(Map value, Style style) {
+    void visitRowField(Map value, Style style, String controller = null, String action = null, Long id = null) {
         String display = value.entrySet().findAll {
             it.value != null
         }.collect { "${it.key}: ${it.value}" }.join(', ')
@@ -227,7 +227,7 @@ final class RawHtmlTableDump implements IUiTableVisitor {
     }
 
     @Override
-    void visitRowField(EnumStyle value, Style style) {
+    void visitRowField(EnumStyle value, Style style, String controller = null, String action = null, Long id = null) {
         if (value?.getStyle()) {
             if (style) style = value.getStyle() + style
             else style = value.getStyle()
@@ -236,7 +236,7 @@ final class RawHtmlTableDump implements IUiTableVisitor {
     }
 
     @Override
-    void visitRowField(BigDecimal value, NumberFormat numberFormat, Style style) {
+    void visitRowField(BigDecimal value, NumberFormat numberFormat, Style style, String controller = null, String action = null, Long id = null) {
         if (value) out << surroundCell(numberFormat.format(value), style ?: new Style(null, "text-align: right;"))
     }
 

--- a/taack-ui/src/main/groovy/taack/ui/vt100/render/RenderingTable.groovy
+++ b/taack-ui/src/main/groovy/taack/ui/vt100/render/RenderingTable.groovy
@@ -88,22 +88,22 @@ final class RenderingTable extends UiTableVisitorImpl {
     }
 
     @Override
-    void visitRowField(String value, Style style) {
+    void visitRowField(String value, Style style, String controller, String action, Long id) {
         drawCell(value.toString())
     }
 
     @Override
-    void visitRowField(Long value, Style style) {
+    void visitRowField(Long value, Style style, String controller, String action, Long id) {
         drawCell(value.toString(), false)
     }
 
     @Override
-    void visitRowField(BigDecimal value, String format, Style style) {
+    void visitRowField(BigDecimal value, String format, Style style, String controller, String action, Long id) {
         drawCell(value.toString(), false)
     }
 
     @Override
-    void visitRowField(Date value, String format, Style style) {
+    void visitRowField(Date value, String format, Style style, String controller, String action, Long id) {
         drawCell(value.toString())
     }
 
@@ -123,7 +123,7 @@ final class RenderingTable extends UiTableVisitorImpl {
     }
 
     @Override
-    void visitRowField(BigDecimal value, NumberFormat numberFormat, Style style) {
+    void visitRowField(BigDecimal value, NumberFormat numberFormat, Style style, String controller, String action, Long id) {
         drawCell(value.toString(), false)
     }
 }


### PR DESCRIPTION
## Change description

 - `rowField` has two new optional parameter: MethodClosure action and Long id
 - Filling out both of the parameters will enclose the text field in <a> tags with the given controller/action/id link

This allows more freedom in the way that UI can be designed.