### PR TITLE
enhancement(table DSL): allow rowAction to be used for text link

### DIFF
--- a/taack-ui/grails-app/assets/stylesheets/taack.css
+++ b/taack-ui/grails-app/assets/stylesheets/taack.css
@@ -117,11 +117,6 @@ form .bootstrap legend {
     bottom: 0;
 }
 
-a:hover {
-    color: #83B6E3;
-    text-decoration: none;
-}
-
 .filter {
     font-size: small;
 }

--- a/taack-ui/src/main/groovy/taack/ui/dsl/table/IUiTableVisitor.groovy
+++ b/taack-ui/src/main/groovy/taack/ui/dsl/table/IUiTableVisitor.groovy
@@ -47,6 +47,8 @@ interface IUiTableVisitor {
 
     void visitRowAction(String i18n, ActionIcon actionIcon, String controller, String action, Long id, Map<String, ?> params, Boolean isAjax)
 
+    void visitRowAction(String i18n, String controller, String action, Long id, Map<String, ?> params, Boolean isAjax)
+
     void visitRowIndent()
 
     void visitRowIndentEnd()

--- a/taack-ui/src/main/groovy/taack/ui/dsl/table/RowColumnFieldSpec.groovy
+++ b/taack-ui/src/main/groovy/taack/ui/dsl/table/RowColumnFieldSpec.groovy
@@ -56,4 +56,20 @@ class RowColumnFieldSpec implements BranchingSpec {
         }
     }
 
+    void rowAction(final String linkText, final MethodClosure action, final Map params) {
+        rowAction(linkText, action, null, params)
+    }
+
+    void rowAction(final String linkText, final MethodClosure action, final Long id) {
+        rowAction(linkText, action, id, null)
+    }
+
+    void rowAction(final String linkText, final MethodClosure action, final Long id, final Map params) {
+        if (taackUiEnablerService.hasAccess(action, id, params)) {
+            Map<String, ?> p = params ?: [:]
+            p.put('id', id)
+            tableVisitor.visitRowAction(linkText, Utils.getControllerName(action), action.method, null, p, true)
+        }
+    }
+
 }

--- a/taack-ui/src/main/groovy/taack/ui/dump/RawCsvTableDump.groovy
+++ b/taack-ui/src/main/groovy/taack/ui/dump/RawCsvTableDump.groovy
@@ -118,6 +118,11 @@ final class RawCsvTableDump implements IUiTableVisitor {
     }
 
     @Override
+    void visitRowAction(String i18n, String controller, String action, Long id, Map<String, ?> params, Boolean isAjax) {
+
+    }
+
+    @Override
     void visitRowIndent() {
 
     }

--- a/taack-ui/src/main/groovy/taack/ui/dump/RawHtmlTableDump.groovy
+++ b/taack-ui/src/main/groovy/taack/ui/dump/RawHtmlTableDump.groovy
@@ -180,6 +180,18 @@ final class RawHtmlTableDump implements IUiTableVisitor {
     }
 
     @Override
+    void visitRowAction(String linkText, final String controller, final String action, final Long id, Map<String, ?> params, final Boolean isAjax) {
+        params ?= [:]
+        blockLog.topElement.addChildren(
+                new HTMLDiv().builder.addChildren(
+                        new HTMLAnchor(isAjax, parameter.urlMapped(controller, action, id, params)).builder.addChildren(
+                                new HTMLTxtContent(linkText)
+                        ).addClasses('table-link').build()
+                ).build()
+        )
+    }
+
+    @Override
     void visitRowColumn(Integer colSpan, Integer rowSpan, Style style) {
         blockLog.enterBlock('visitRowColumn')
         isInCol = true

--- a/taack-ui/src/main/groovy/taack/ui/dump/vt100/RenderingTable.groovy
+++ b/taack-ui/src/main/groovy/taack/ui/dump/vt100/RenderingTable.groovy
@@ -136,6 +136,11 @@ final class RenderingTable implements IUiTableVisitor {
     }
 
     @Override
+    void visitRowAction(String i18n, String controller, String action, Long id, Map<String, ?> params, Boolean isAjax) {
+
+    }
+
+    @Override
     void visitRowIndent() {
 
     }


### PR DESCRIPTION
# Enhancement: Allow `rowAction` to be used for text links

## Description

Enhances the table DSL by allowing the `rowAction` method to be used for text links in addition to its existing functionality.

## Changes Made

1. **New method overloads in `RowColumnFieldSpec.groovy`**:
    - Added method overloads for `rowAction` to accept different parameter combinations tailored for text link instead of ActionIcons

2. **Implementation of new `visitRowAction` methods**:
    - Added new visitRowAction methods in the following classes:
        - `RawHtmlTableDump.groovy`
        - `RawCsvTableDump.groovy` (Empty like the already existing one)
        - `RenderingTable.groovy`(Empty like the already existing one)

3. **CSS Modification**:
    - Removed specific styling for hovered anchor (`a:hover`) elements to allow users to use their own custom styling without working out priority or using `!important`. Especially since we don't style anchor by default.
    - Added classes to text link anchors to avoid conflict with bootstrap css and leave more flexibility for users

Thank you, feel free to add your feedback!