### PR TITLE
Slight render rework and performance optimizations

### DIFF
--- a/taack-ui/grails-app/services/taack/render/TaackUiService.groovy
+++ b/taack-ui/grails-app/services/taack/render/TaackUiService.groovy
@@ -525,7 +525,7 @@ final class TaackUiService implements WebAttributes, ResponseRenderer, DataBinde
 
 //        AssetResourceLocator assets = assetResourceLocator as AssetResourceLocator
 
-        BufferedOutputStream bout = new BufferedOutputStream(webRequest.response.outputStream, 4096)
+        BufferedOutputStream bout = new BufferedOutputStream(webRequest.response.outputStream, bufferSize)
 
         TaackUiConfiguration conf
         bout << """\

--- a/taack-ui/src/main/groovy/taack/ui/dsl/form/FormAjaxFieldSpec.groovy
+++ b/taack-ui/src/main/groovy/taack/ui/dsl/form/FormAjaxFieldSpec.groovy
@@ -29,15 +29,11 @@ class FormAjaxFieldSpec extends FormVisitable {
     void tabs(BlockSpec.Width width = BlockSpec.Width.MAX, @DelegatesTo(strategy = Closure.DELEGATE_ONLY, value = FormTabSpec) Closure closure) {
         List<String> tabNames = []
 
-        UiFormVisitorImpl tabNameVisitor = new UiFormVisitorImpl() {
-            @Override
-            void visitFormTab(String i18n) {
-                tabNames << i18n
-            }
-        }
-        closure.delegate = new FormTabSpec(tabNameVisitor)
+        // Lightweight first pass: collect tab names WITHOUT executing inner closures
+        closure.delegate = new FormTabNameCollector(tabNames)
         closure.call()
 
+        // Second pass: real rendering with names already known
         formVisitor.visitFormTabs(tabNames, width)
         closure.delegate = new FormTabSpec(formVisitor)
         closure.call()

--- a/taack-ui/src/main/groovy/taack/ui/dsl/form/FormTabNameCollector.groovy
+++ b/taack-ui/src/main/groovy/taack/ui/dsl/form/FormTabNameCollector.groovy
@@ -1,0 +1,24 @@
+package taack.ui.dsl.form
+
+import groovy.transform.CompileStatic
+
+/**
+ * Used to get tab names from tabLabel() calls without running the inner closures.
+ * Extends FormTabSpec so the closure's @DelegatesTo works.
+ */
+@CompileStatic
+final class FormTabNameCollector extends FormTabSpec {
+
+    final List<String> tabNames
+
+    FormTabNameCollector(List<String> tabNames) {
+        super(new UiFormVisitorImpl())
+        this.tabNames = tabNames
+    }
+
+    @Override
+    void tabLabel(String sectionName, @DelegatesTo(strategy = Closure.DELEGATE_ONLY, value = FormRowSpec) Closure closure) {
+        tabNames << sectionName
+        // Intentionally NOT calling closure, this just collects name
+    }
+}

--- a/taack-ui/src/main/groovy/taack/ui/dsl/form/FormTabSpec.groovy
+++ b/taack-ui/src/main/groovy/taack/ui/dsl/form/FormTabSpec.groovy
@@ -3,7 +3,7 @@ package taack.ui.dsl.form
 import groovy.transform.CompileStatic
 
 @CompileStatic
-final class FormTabSpec {
+class FormTabSpec {
 
     final IUiFormVisitor formVisitor
 

--- a/taack-ui/src/main/groovy/taack/ui/dump/RawHtmlBlockDump.groovy
+++ b/taack-ui/src/main/groovy/taack/ui/dump/RawHtmlBlockDump.groovy
@@ -24,155 +24,97 @@ import taack.ui.dump.html.menu.BootstrapMenu
 
 @CompileStatic
 final class RawHtmlBlockDump implements IUiBlockVisitor {
-    private String currentAjaxBlockId = null
     final String modalId
     String futurCurrentAjaxBlockId
-    String theCurrentExplicitAjaxBlockId
 
     Map<String, byte[]> mailAttachment = [:]
 
-    boolean isModal = false
-    boolean isRefreshing = false
-    boolean renderTab = false
     int poll = 0
-
-    private boolean poke = false
 
     private int tabOccurrence = 0
 
     final BootstrapBlock block
     final Parameter parameter
+    final RenderDecision renderDecision
 
     private final BlockLog blockLog
-    
+
     void simpleLog(String toPrint) {
         blockLog.simpleLog(RawHtmlBlockDump.simpleName + '::' + toPrint)
     }
 
-    void enterBlock(String toPrint) {
-        blockLog.enterBlock(RawHtmlBlockDump.simpleName + '::' + toPrint)
+    void logEnterBlock(String toPrint) {
+        blockLog.logEnterBlock(RawHtmlBlockDump.simpleName + '::' + toPrint)
     }
 
-    void exitBlock(String toPrint) {
-        blockLog.exitBlock(RawHtmlBlockDump.simpleName + '::' + toPrint)
+    void logExitBlock(String toPrint) {
+        blockLog.logExitBlock(RawHtmlBlockDump.simpleName + '::' + toPrint)
     }
 
     RawHtmlBlockDump(final Parameter parameter) {
         this.parameter = parameter
         this.modalId = modalId
-        if (parameter.params.boolean('refresh'))
-            isRefreshing = true
         blockLog = new BlockLog(parameter.uiThemeService.themeSelector)
+        renderDecision = new RenderDecision(parameter, blockLog)
         block = new BootstrapBlock(blockLog, this.parameter)
-//        menu = new BootstrapMenu(blockLog)
         blockLog.topElement = new HTMLEmpty()
         blockLog.topElement.setTaackTag(TaackTag.BLOCK)
     }
 
-    /**
-     * Check if a block DSL element has to be rendered. If a page contains multiple block, and user click on
-     * a table to sort, only the table will be rendered when processing the DSL.
-     *
-     * * If the page is not ajax, everything is rendered
-     * * else
-     * * * If no explicit ajaxBlock, only current or target ajaxBlock is rendered
-     * * * If explicit ajaxBlocks are specified (via {@link #setExplicitAjaxBlockId(String id) setAjaxBlockId}),
-     *     only then will be rendered if in ajax mode (parameter.isAjaxRendering == true)
-     *
-     * @param id
-     * @return
-     */
     @Override
     boolean doRenderElement(String id = null) {
-        // if many blocks in the same response, only redraw current block
-        // further the first block must be in ajaxMode until current block ends
-        if (parameter.target == Parameter.RenderingTarget.MAIL) return true
-        if (poke) return true
-        simpleLog("doRenderElement0 :> renderTab: $renderTab, id: $id, theCurrentExplicitAjaxBlockId: ${theCurrentExplicitAjaxBlockId}, isModal: ${isModal}, params: ${parameter.params}")
-
-        if (!parameter.isAjaxRendering) {
-            simpleLog('doRenderElement01: true')
-            return true
-        }
-        if (renderTab && parameter.isAjaxRendering) {
-            simpleLog('doRenderElement02: true')
-           return true
-        }
-
-//        if (parameter.isAjaxRendering && theCurrentExplicitAjaxBlockId == parameter.ajaxBlockId) return true
-//        else if (parameter.isAjaxRendering && parameter.ajaxBlockId && theCurrentExplicitAjaxBlockId != parameter.ajaxBlockId) return false
-
-        if ((!id && (!parameter.isAjaxRendering && !isModal) || theCurrentExplicitAjaxBlockId != null)) {
-            boolean ret = !parameter.tabId && !parameter.ajaxBlockId || parameter.ajaxBlockId == theCurrentExplicitAjaxBlockId
-            simpleLog("doRenderElement1 return ${ret}, because NOT (AJAX OR MODAL) OR AJAX BUT ANOTHER id")
-            return ret
-        } else if (!id && !parameter.ajaxBlockId) {
-            simpleLog("doRenderElement2 return isModal($isModal && $poke)")
-            return isModal
-        }
-
-        if (parameter.isAjaxRendering && currentAjaxBlockId == null) {
-            currentAjaxBlockId = parameter.ajaxBlockId
-        }
-
-        if (parameter.targetAjaxBlockId) {
-            currentAjaxBlockId = parameter.targetAjaxBlockId
-        }
-
-        simpleLog("doRenderElement3 :> currentAjaxBlockId = ${currentAjaxBlockId}, targetAjaxBlockId = ${parameter.targetAjaxBlockId}, ajaxBlockId = ${parameter.ajaxBlockId}")
-
-        boolean doRender = (currentAjaxBlockId == id && (isModal || isRefreshing)) || (!currentAjaxBlockId && isModal) //&& !parameter.isRefresh) // || parameter.targetAjaxBlockId //|| (parameter.isAjaxRendering && currentAjaxBlockId == parameter.ajaxBlockId)
-        simpleLog("doRenderElement4 => doRender = $doRender && $poke")
-        return doRender
+        renderDecision.shouldRender(id)
     }
 
     @Override
     boolean doRenderLayoutElement() {
-        simpleLog("doRenderLayoutElement ${parameter.isAjaxRendering}, ${parameter.ajaxBlockId} $currentAjaxBlockId ${parameter.targetAjaxBlockId}")
-        return !parameter.isAjaxRendering
+        renderDecision.shouldRenderLayout()
     }
 
     @Override
     void setRenderTab(boolean isRender) {
-        renderTab = isRender || parameter.target == Parameter.RenderingTarget.MAIL
+        renderDecision.renderTab = isRender || parameter.target == Parameter.RenderingTarget.MAIL
     }
 
     @Override
     void visitBlock() {
-        enterBlock('visitBlock')
+        logEnterBlock('visitBlock')
+        blockLog.savePosition()
         blockLog.topElement = block.block(blockLog.topElement, "${parameter.applicationTagLib.controllerName}-${parameter.applicationTagLib.actionName}")
     }
 
     @Override
     void visitBlockEnd() {
-        exitBlock('visitBlockEnd')
-        blockLog.topElement = blockLog.topElement.toParentTaackTag(TaackTag.BLOCK)
+        logExitBlock('visitBlockEnd')
+        blockLog.restorePosition()
     }
 
     @Override
     void visitBlockHeader() {
-        enterBlock('visitBlockHeader')
+        logEnterBlock('visitBlockHeader')
+        blockLog.savePosition()
         blockLog.topElement.setTaackTag(TaackTag.MENU_BLOCK)
         blockLog.topElement = block.blockHeader(blockLog.topElement)
     }
 
     @Override
     void visitBlockHeaderEnd() {
-        exitBlock('visitBlockHeaderEnd')
-        blockLog.topElement = blockLog.topElement.toParentTaackTag(TaackTag.MENU_BLOCK)
+        logExitBlock('visitBlockHeaderEnd')
+        blockLog.restorePosition()
     }
 
     @Override
     void visitCol(final BlockSpec.Width width) {
-        enterBlock('visitCol')
+        logEnterBlock('visitCol')
+        blockLog.savePosition()
         blockLog.topElement.setTaackTag(TaackTag.COL)
         blockLog.topElement = block.col(blockLog.topElement, width)
     }
 
     @Override
     void visitColEnd() {
-        exitBlock('visitColEnd')
-        blockLog.topElement = blockLog.topElement.toParentTaackTag(TaackTag.COL)
+        logExitBlock('visitColEnd')
+        blockLog.restorePosition()
     }
 
     /**
@@ -184,13 +126,14 @@ final class RawHtmlBlockDump implements IUiBlockVisitor {
      */
     @Override
     void visitAjaxBlock(String id) {
-        enterBlock('visitAjaxBlock id: ' + id + ' parameter.isAjaxRendering: ' + parameter.isAjaxRendering + ' parameter.ajaxBlockId: ' + parameter.ajaxBlockId)
+        logEnterBlock('visitAjaxBlock id: ' + id + ' parameter.isAjaxRendering: ' + parameter.isAjaxRendering + ' parameter.ajaxBlockId: ' + parameter.ajaxBlockId)
+        blockLog.savePosition()
         if (!id) id = parameter.ajaxBlockId
         blockLog.topElement.setTaackTag(TaackTag.AJAX_BLOCK)
 
         // doAjaxRendering == true : to ajax refresh the content of an existing block
         boolean doAjaxRendering = parameter.isAjaxRendering // must be in ajaxMode
-        if ((id != theCurrentExplicitAjaxBlockId || isModal) && id != currentAjaxBlockId) {
+        if ((id != renderDecision.explicitAjaxBlockId || renderDecision.isModal) && id != renderDecision.currentAjaxBlockId) {
             // if many blocks in the same response, only redraw current block
             doAjaxRendering = false
         }
@@ -198,7 +141,7 @@ final class RawHtmlBlockDump implements IUiBlockVisitor {
             // insert content to an empty tab, so not for the refresh of an existing block
             doAjaxRendering = false
         }
-        if (isModal && !isRefreshing) {
+        if (renderDecision.isModal && !renderDecision.isRefreshing) {
             // Open a new modal (Not refreshing an existing modal), so not for the refresh of an existing block
             doAjaxRendering = false
         }
@@ -207,27 +150,27 @@ final class RawHtmlBlockDump implements IUiBlockVisitor {
             id = parameter.targetAjaxBlockId
             doAjaxRendering = true
         }
-        if (poke) doAjaxRendering = true
+        if (renderDecision.poke) doAjaxRendering = true
         blockLog.topElement = block.blockAjax(blockLog.topElement, id, doAjaxRendering)
     }
 
     @Override
     void visitAjaxBlockEnd() {
-        exitBlock('visitAjaxBlockEnd')
-        currentAjaxBlockId = null
-        blockLog.topElement = blockLog.topElement.toParentTaackTag(TaackTag.AJAX_BLOCK)
+        logExitBlock('visitAjaxBlockEnd')
+        renderDecision.currentAjaxBlockId = null
+        blockLog.restorePosition()
     }
 
     @Override
     void visitForm(UiFormSpecifier formSpecifier) {
-        blockLog.stayBlock('visitForm')
+        blockLog.logStayBlock('visitForm')
         formSpecifier.visitForm(new RawHtmlFormDump(blockLog, parameter))
     }
 
 
     @Override
     void visitShow(final UiShowSpecifier uiShowSpecifier) {
-        blockLog.stayBlock('visitShow')
+        blockLog.logStayBlock('visitShow')
         ByteArrayOutputStream out = new ByteArrayOutputStream(4096)
         if (uiShowSpecifier) uiShowSpecifier.visitShow(new RawHtmlShowDump(id, out, parameter))
         blockLog.topElement.addChildren(new HTMLOutput(out))
@@ -235,18 +178,18 @@ final class RawHtmlBlockDump implements IUiBlockVisitor {
 
     @Override
     void visitCloseModalAndUpdateBlock() {
-        enterBlock('visitCloseModalAndUpdateBlock')
+        logEnterBlock('visitCloseModalAndUpdateBlock')
         blockLog.topElement = new HTMLAjaxCloseModal()
     }
 
     @Override
     void visitCloseModalAndUpdateBlockEnd() {
-        exitBlock('visitCloseModalAndUpdateBlockEnd')
+        logExitBlock('visitCloseModalAndUpdateBlockEnd')
     }
 
     @Override
     void visitHtmlBlock(String html, Style style) {
-        blockLog.stayBlock('visitHtmlBlock')
+        blockLog.logStayBlock('visitHtmlBlock')
         blockLog.topElement.addChildren(
                 new HTMLDiv().builder.addClasses(style?.cssClassesString).putAttribute('style', style?.cssStyleString).addChildren(
                         new HTMLTxtContent(html)
@@ -256,7 +199,7 @@ final class RawHtmlBlockDump implements IUiBlockVisitor {
 
     @Override
     void visitIframe(String url, String cssHeight) {
-        blockLog.stayBlock('visitIframe')
+        blockLog.logStayBlock('visitIframe')
         blockLog.topElement.addChildren(
                 new HTMLIFrame(url, cssHeight)
         )
@@ -264,7 +207,7 @@ final class RawHtmlBlockDump implements IUiBlockVisitor {
 
     @Override
     void visitPoll(int millis, MethodClosure polledAction) {
-        enterBlock('visitPoll ' + millis + ' ms ' + polledAction.toString())
+        logEnterBlock('visitPoll ' + millis + ' ms ' + polledAction.toString())
         poll = millis
         HTMLAjaxPoll poll = new HTMLAjaxPoll(millis, parameter.urlMapped(polledAction))
         blockLog.topElement.addChildren(poll)
@@ -274,14 +217,14 @@ final class RawHtmlBlockDump implements IUiBlockVisitor {
 
     @Override
     void visitPollEnd() {
-        enterBlock('visitPollEnd')
+        logEnterBlock('visitPollEnd')
         blockLog.topElement = blockLog.topElement.toParentTaackTag(TaackTag.MODAL)
         poll = 0
     }
 
     @Override
     void visitTable(String id, final UiTableSpecifier tableSpecifier) {
-        blockLog.stayBlock('visitTable ' + id)
+        blockLog.logStayBlock('visitTable ' + id)
         tableSpecifier.visitTableWithNoFilter(new RawHtmlTableDump(blockLog, id, parameter))
     }
 
@@ -289,7 +232,7 @@ final class RawHtmlBlockDump implements IUiBlockVisitor {
     void visitTableFilter(final String id,
                           final UiFilterSpecifier filterSpecifier,
                           final UiTableSpecifier tableSpecifier) {
-        blockLog.stayBlock('visitTableFilter ' + id)
+        blockLog.logStayBlock('visitTableFilter ' + id)
         visitCol(BlockSpec.Width.QUARTER)
         IUiTableVisitor tableVisitor = new RawHtmlTableDump(blockLog, id, parameter)
         IUiFilterVisitor filterVisitor = new RawHtmlFilterDump(blockLog, id, parameter)
@@ -315,7 +258,7 @@ final class RawHtmlBlockDump implements IUiBlockVisitor {
 
     @Override
     void visitKanban(String id, UiKanbanSpecifier kanbanSpecifier) {
-        blockLog.stayBlock('visitKanban ' + id)
+        blockLog.logStayBlock('visitKanban ' + id)
         kanbanSpecifier.visitKanbanWithoutFilter(new RawHtmlKanbanDump(blockLog, id, parameter))
     }
 
@@ -323,7 +266,7 @@ final class RawHtmlBlockDump implements IUiBlockVisitor {
     void visitKanbanFilter(final String id,
                            final UiFilterSpecifier filterSpecifier,
                            final UiKanbanSpecifier kanbanSpecifier) {
-        blockLog.stayBlock('visitKanbanFilter ' + id)
+        blockLog.logStayBlock('visitKanbanFilter ' + id)
         visitCol(BlockSpec.Width.QUARTER)
         IUiKanbanVisitor kanbanVisitor = new RawHtmlKanbanDump(blockLog, id, parameter)
         IUiFilterVisitor filterVisitor = new RawHtmlFilterDump(blockLog, id, parameter)
@@ -345,7 +288,7 @@ final class RawHtmlBlockDump implements IUiBlockVisitor {
 
     @Override
     void visitDiagramFilter(final UiDiagramSpecifier diagramSpecifier, final UiFilterSpecifier filterSpecifier) {
-        blockLog.stayBlock('visitDiagramFilter')
+        blockLog.logStayBlock('visitDiagramFilter')
         visitCol(BlockSpec.Width.QUARTER)
         IUiFilterVisitor filterVisitor = new RawHtmlFilterDump(blockLog, id, parameter)
         filterSpecifier.visitFilter(filterVisitor)
@@ -360,7 +303,7 @@ final class RawHtmlBlockDump implements IUiBlockVisitor {
 
     @Override
     void visitDiagram(final UiDiagramSpecifier diagramSpecifier) {
-        blockLog.stayBlock('visitDiagram')
+        blockLog.logStayBlock('visitDiagram')
         if (parameter.target == Parameter.RenderingTarget.MAIL) {
             RawHtmlDiagramDump diagramDump = new RawHtmlDiagramDump(new ByteArrayOutputStream(4096), blockLog, mailAttachment)
             diagramSpecifier.visitDiagram(diagramDump, UiDiagramSpecifier.DiagramBase.PNG)
@@ -370,7 +313,7 @@ final class RawHtmlBlockDump implements IUiBlockVisitor {
 
     @Override
     void visitCloseModal(final Map<String, String> idValueMap, FieldInfo[] fields = null) {
-        blockLog.stayBlock('visitCloseModal')
+        blockLog.logStayBlock('visitCloseModal')
         blockLog.topElement.addChildren(new HTMLAjaxCloseLastModal(idValueMap))
         for (FieldInfo fi : fields) {
             String label
@@ -389,7 +332,8 @@ final class RawHtmlBlockDump implements IUiBlockVisitor {
 
     @Override
     void visitBlockTab(final String i18n) {
-        enterBlock('visitBlockTab')
+        logEnterBlock('visitBlockTab')
+        blockLog.savePosition()
         currentTabNames << i18n
         blockLog.topElement.setTaackTag(TaackTag.TAB)
         blockLog.topElement = block.tab(blockLog.topElement, tabOccurrence++)
@@ -397,54 +341,55 @@ final class RawHtmlBlockDump implements IUiBlockVisitor {
 
     @Override
     void visitBlockTabEnd() {
-        exitBlock('visitBlockTabEnd')
-        blockLog.topElement = blockLog.topElement.toParentTaackTag(TaackTag.TAB)
+        logExitBlock('visitBlockTabEnd')
+        blockLog.restorePosition()
     }
 
     private List<String> currentTabNames = []
-    private IHTMLElement oldParent = null
 
     @Override
     void visitBlockTabs() {
-        enterBlock('visitBlockTabs')
-        oldParent = blockLog.topElement
-        oldParent.setTaackTag(TaackTag.TABS)
+        logEnterBlock('visitBlockTabs')
+        blockLog.savePosition()
+        blockLog.topElement.setTaackTag(TaackTag.TABS)
         blockLog.topElement = new HTMLEmpty()
     }
 
     @Override
     void visitBlockTabsEnd() {
-        exitBlock('visitBlockTabsEnd')
+        logExitBlock('visitBlockTabsEnd')
         IHTMLElement tabsContent = blockLog.topElement
+        IHTMLElement savedParent = blockLog.peekPosition()
         Map<String, Object> p = parameter.params.sort()
         if (p) p.remove('tabIndex')
-        blockLog.topElement = block.tabs(oldParent, currentTabNames, parameter.urlMapped(parameter.applicationTagLib.controllerName, parameter.applicationTagLib.actionName, parameter.beanId, p))
+        blockLog.topElement = block.tabs(savedParent, currentTabNames, parameter.urlMapped(parameter.applicationTagLib.controllerName, parameter.applicationTagLib.actionName, parameter.beanId, p))
         blockLog.topElement.addChildren(tabsContent)
-        blockLog.topElement = blockLog.topElement.toParentTaackTag(TaackTag.TABS)
+        blockLog.restorePosition()
     }
 
     @Override
     void visitBlockPoke(boolean update) {
-        poke = poke || update
+        renderDecision.poke = renderDecision.poke || update
     }
 
     @Override
     void visitBlockPokeEnd() {
-        poke = false
+        renderDecision.poke = false
     }
 
     @Override
     void visitCustom(final String html, Style style) {
-        blockLog.stayBlock('visitCustom')
+        blockLog.logStayBlock('visitCustom')
         visitHtmlBlock(html, style)
     }
 
     @Override
     void visitModal(boolean reloadWhenClose) {
-        enterBlock('visitModal modalId:' + modalId + ' isModalRefresh:' + isRefreshing)
-        isModal = true
+        logEnterBlock('visitModal modalId:' + modalId + ' isModalRefresh:' + renderDecision.isRefreshing)
+        blockLog.savePosition()
+        renderDecision.isModal = true
         parameter.isModal = true
-        HTMLAjaxModal modal = new HTMLAjaxModal(isRefreshing, reloadWhenClose)
+        HTMLAjaxModal modal = new HTMLAjaxModal(renderDecision.isRefreshing, reloadWhenClose)
         blockLog.topElement.addChildren(modal)
         blockLog.topElement.setTaackTag(TaackTag.MODAL)
         blockLog.topElement = modal
@@ -452,25 +397,19 @@ final class RawHtmlBlockDump implements IUiBlockVisitor {
 
     @Override
     void visitModalEnd() {
-        exitBlock('visitModalEnd')
-        isModal = false
-        blockLog.topElement = blockLog.topElement.toParentTaackTag(TaackTag.MODAL)
+        logExitBlock('visitModalEnd')
+        renderDecision.isModal = false
+        blockLog.restorePosition()
     }
 
     @Override
     String getExplicitAjaxBlockId() {
-        theCurrentExplicitAjaxBlockId
+        renderDecision.explicitAjaxBlockId
     }
 
-    /**
-     * Set explicit ajaxBlockId to for ajax mode and for render.
-     * (See {@link #visitAjaxBlock}
-     *
-     * @param id
-     */
     @Override
     void setExplicitAjaxBlockId(String id) {
-        theCurrentExplicitAjaxBlockId = id
+        renderDecision.explicitAjaxBlockId = id
     }
 
     @Override
@@ -480,38 +419,51 @@ final class RawHtmlBlockDump implements IUiBlockVisitor {
 
     @Override
     void visitRow() {
-        enterBlock('visitRow')
+        logEnterBlock('visitRow')
+        blockLog.savePosition()
         blockLog.topElement.setTaackTag(TaackTag.ROW)
         blockLog.topElement = block.row(blockLog.topElement)
     }
 
     @Override
     void visitRowEnd() {
-        exitBlock('visitRowEnd')
-        blockLog.topElement = blockLog.topElement.toParentTaackTag(TaackTag.ROW)
+        logExitBlock('visitRowEnd')
+        blockLog.restorePosition()
     }
 
     BootstrapMenu menu
     boolean insideMenuSection = false
 
+    private boolean menuLabelSaved = false
+
     @Override
     void visitMenuLabel(String i18n, boolean hasClosure) {
-        if (hasClosure) enterBlock('visitMenuLabel ' + i18n)
-        else blockLog.stayBlock('visitMenuLabel ' + i18n)
+        if (hasClosure) {
+            blockLog.savePosition()
+            menuLabelSaved = true
+            logEnterBlock('visitMenuLabel ' + i18n)
+        } else {
+            menuLabelSaved = false
+            blockLog.logStayBlock('visitMenuLabel ' + i18n)
+        }
         blockLog.topElement.setTaackTag(TaackTag.LABEL)
-
         blockLog.topElement = menu.label(blockLog.topElement, i18n, hasClosure)
     }
 
     @Override
     void visitMenuLabelEnd() {
-        exitBlock('visitMenuLabelEnd')
-        blockLog.topElement = blockLog.topElement.toParentTaackTag(TaackTag.LABEL)
+        logExitBlock('visitMenuLabelEnd')
+        if (menuLabelSaved) {
+            blockLog.restorePosition()
+        } else {
+            blockLog.topElement = blockLog.topElement.toParentTaackTag(TaackTag.LABEL)
+        }
     }
 
     @Override
     void visitMenuStart(MenuSpec.MenuMode menuMode, String ajaxBlockId) {
-        enterBlock('visitMenuStart futurCurrentAjaxBlockId: ' + ajaxBlockId)
+        logEnterBlock('visitMenuStart futurCurrentAjaxBlockId: ' + ajaxBlockId)
+        blockLog.savePosition()
         futurCurrentAjaxBlockId = ajaxBlockId
         blockLog.topElement.setTaackTag(TaackTag.MENU)
         menu = new BootstrapMenu(parameter.target == Parameter.RenderingTarget.MAIL, blockLog)
@@ -520,49 +472,49 @@ final class RawHtmlBlockDump implements IUiBlockVisitor {
 
     @Override
     void visitMenuStartEnd() {
-        exitBlock('visitMenuStartEnd')
+        logExitBlock('visitMenuStartEnd')
         futurCurrentAjaxBlockId = null
-        blockLog.topElement = blockLog.topElement.toParentTaackTag(TaackTag.MENU)
+        blockLog.restorePosition()
     }
 
     private void splitMenu() {
         if (!blockLog.topElement.testParentTaackTag(TaackTag.MENU_SPLIT)) {
-            blockLog.stayBlock('splitMenu +++')
+            blockLog.logStayBlock('splitMenu +++')
             blockLog.topElement = menu.splitMenuStart(blockLog.topElement.parent)
             blockLog.topElement.setTaackTag(TaackTag.MENU_SPLIT)
-            blockLog.stayBlock('splitMenu ---')
+            blockLog.logStayBlock('splitMenu ---')
         } else {
-            blockLog.stayBlock('splitMenu -+-+-+-')
+            blockLog.logStayBlock('splitMenu -+-+-+-')
         }
 
     }
 
     private void splitMenuEnd() {
         if (blockLog.topElement.testParentTaackTag(TaackTag.MENU_SPLIT)) {
-            blockLog.stayBlock('splitMenuEnd TRUE')
+            blockLog.logStayBlock('splitMenuEnd TRUE')
             blockLog.topElement = blockLog.topElement.toParentTaackTag(TaackTag.MENU_SPLIT)
         } else {
-            blockLog.stayBlock('splitMenuEnd FALSE')
+            blockLog.logStayBlock('splitMenuEnd FALSE')
         }
     }
 
     @Override
     void visitMenu(String controller, String action, Map<String, ?> params) {
-        blockLog.stayBlock('visitMenu')
+        blockLog.logStayBlock('visitMenu')
         visitLabeledSubMenu(null, controller, action, params)
     }
 
 
     @Override
     void visitSubMenu(String controller, String action, Map<String, ?> params) {
-        blockLog.stayBlock('visitSubMenu')
+        blockLog.logStayBlock('visitSubMenu')
         visitLabeledSubMenu(null, controller, action, params)
     }
 
     void visitLabeledSubMenu(String i18n, String controller, String action, Map<String, ?> params) {
         i18n ?= parameter.trField(controller, action, params?.containsKey('id'))
 
-        blockLog.stayBlock('visitLabeledSubMenu ' + i18n)
+        blockLog.logStayBlock('visitLabeledSubMenu ' + i18n)
         Map cp = parameter.params
         if (params) {
             if (cp.containsKey('lang') && !params.containsKey('lang')) cp.remove('lang')
@@ -597,21 +549,21 @@ final class RawHtmlBlockDump implements IUiBlockVisitor {
 
     @Override
     void visitMenuSection(String i18n, MenuSpec.MenuPosition position) {
-        enterBlock('visitMenuSection ' + i18n)
+        logEnterBlock('visitMenuSection ' + i18n)
         insideMenuSection = true
         menu.section(blockLog.topElement, i18n)
     }
 
     @Override
     void visitMenuSectionEnd() {
-        exitBlock('visitMenuSectionEnd')
+        logExitBlock('visitMenuSectionEnd')
         insideMenuSection = false
     }
 
     @Override
     void visitSubMenuIcon(String i18n, ActionIcon actionIcon, String controller, String action, Map<String, ?> params, boolean isModal = false) {
         i18n ?= parameter.trField(controller, action, params?.containsKey('id'))
-        blockLog.stayBlock('visitSubMenuIcon ' + i18n)
+        blockLog.logStayBlock('visitSubMenuIcon ' + i18n)
         if (!blockLog.topElement.testParentTaackTag(TaackTag.MENU_SPLIT, TaackTag.MENU_COL)) {
             splitMenu()
         }
@@ -624,7 +576,8 @@ final class RawHtmlBlockDump implements IUiBlockVisitor {
 
     @Override
     void visitMenuIconWithClosure(String i18n, ActionIcon actionIcon) {
-        enterBlock('visitMenuIconWithClosure ' + i18n)
+        logEnterBlock('visitMenuIconWithClosure ' + i18n)
+        blockLog.savePosition()
         blockLog.topElement.setTaackTag(TaackTag.MENU_COL)
 
         blockLog.topElement = menu.label(blockLog.topElement, actionIcon.getHtml(i18n, 24), true).builder.build()
@@ -632,14 +585,14 @@ final class RawHtmlBlockDump implements IUiBlockVisitor {
 
     @Override
     void visitMenuIconWithClosureEnd(Style style) {
-        exitBlock('visitMenuIconWithClosureEnd')
-        blockLog.topElement = blockLog.topElement.toParentTaackTag(TaackTag.MENU_COL)
-        if (Style) blockLog.topElement.children.last().setStyleDescriptor(style)
+        logExitBlock('visitMenuIconWithClosureEnd')
+        blockLog.restorePosition()
+        if (style) blockLog.topElement.children.last().setStyleDescriptor(style)
     }
 
     @Override
     void visitMenuSelect(String paramName, IEnumOptions enumOptions, Map<String, ?> params) {
-        enterBlock('visitMenuSelect')
+        logEnterBlock('visitMenuSelect')
         String valueSelected = params[paramName]
         IEnumOption enumSelected = enumOptions.getOptions().find { it.key == valueSelected }
         String controller = params['controller'] as String
@@ -655,16 +608,16 @@ final class RawHtmlBlockDump implements IUiBlockVisitor {
     void visitMenuSearch(MethodClosure action, String q, Class<? extends GormEntity>[] aClasses) {
         String i18n = parameter.trField(Utils.getControllerName(action), action.method.toString(), false)
 
-        enterBlock('visitMenuSearch')
+        logEnterBlock('visitMenuSearch')
         splitMenu()
         menu.menuSearch(blockLog.topElement, i18n, q?.replace('"', '&quot;'), parameter.urlMapped(Utils.getControllerName(action), action.method))
         splitMenuEnd()
-        exitBlock('visitMenuSearch')
+        logExitBlock('visitMenuSearch')
     }
 
     @Override
     void visitMenuOptions(IEnumOptions enumOptions) {
-        enterBlock('visitMenuOptions')
+        logEnterBlock('visitMenuOptions')
         splitMenu()
         String selectedOptionKey = parameter.params[enumOptions.paramKey]
 
@@ -672,8 +625,8 @@ final class RawHtmlBlockDump implements IUiBlockVisitor {
         String selectedOptionValue = currentOption ? currentOption.value : selectedOptionKey
         String img = currentOption && currentOption.asset? parameter.applicationTagLib.img(file: currentOption.asset, width: 20, style: 'padding: .5em 0em;') : ''
 
+        blockLog.savePosition()
         blockLog.topElement = menu.menuOptions(blockLog.topElement, img, selectedOptionValue)
-        blockLog.topElement.setTaackTag(TaackTag.MENU_OPTION)
 
         String controller = parameter.controllerName
         String action = parameter.actionName
@@ -694,9 +647,9 @@ final class RawHtmlBlockDump implements IUiBlockVisitor {
             }
         }
         parameter.params.remove(enumOptions.paramKey)
-        blockLog.topElement = blockLog.topElement.toParentTaackTag(TaackTag.MENU_OPTION)
+        blockLog.restorePosition()
         splitMenuEnd()
-        exitBlock('visitMenuOptions')
+        logExitBlock('visitMenuOptions')
     }
 
     // --- Accordion ---
@@ -706,7 +659,8 @@ final class RawHtmlBlockDump implements IUiBlockVisitor {
 
     @Override
     void visitBlockAccordion() {
-        enterBlock('visitBlockAccordion')
+        logEnterBlock('visitBlockAccordion')
+        blockLog.savePosition()
         blockLog.topElement.setTaackTag(TaackTag.ACCORDION)
         currentAccordionElement = block.accordion(blockLog.topElement)
         blockLog.topElement = currentAccordionElement
@@ -715,22 +669,23 @@ final class RawHtmlBlockDump implements IUiBlockVisitor {
 
     @Override
     void visitBlockAccordionEnd() {
-        exitBlock('visitBlockAccordionEnd')
+        logExitBlock('visitBlockAccordionEnd')
         currentAccordionElement = null
-        blockLog.topElement = blockLog.topElement.toParentTaackTag(TaackTag.ACCORDION)
+        blockLog.restorePosition()
     }
 
     @Override
     void visitBlockAccordionItem(String i18n, boolean openByDefault) {
-        enterBlock('visitBlockAccordionItem ' + i18n)
+        logEnterBlock('visitBlockAccordionItem ' + i18n)
+        blockLog.savePosition()
         blockLog.topElement.setTaackTag(TaackTag.ACCORDION_ITEM)
         blockLog.topElement = block.accordionItem(currentAccordionElement, i18n, accordionItemIndex++, openByDefault)
     }
 
     @Override
     void visitBlockAccordionItemEnd() {
-        exitBlock('visitBlockAccordionItemEnd')
-        blockLog.topElement = blockLog.topElement.toParentTaackTag(TaackTag.ACCORDION_ITEM)
+        logExitBlock('visitBlockAccordionItemEnd')
+        blockLog.restorePosition()
     }
 
     // --- Card ---
@@ -740,7 +695,8 @@ final class RawHtmlBlockDump implements IUiBlockVisitor {
 
     @Override
     void visitBlockCard(String title, boolean hasMenu) {
-        enterBlock('visitBlockCard ' + title)
+        logEnterBlock('visitBlockCard ' + title)
+        blockLog.savePosition()
         blockLog.topElement.setTaackTag(TaackTag.CARD)
         cardHeaderElement = block.cardStart(blockLog.topElement, title, hasMenu)
         // cardStart adds the card div as last child of topElement
@@ -750,31 +706,32 @@ final class RawHtmlBlockDump implements IUiBlockVisitor {
 
     @Override
     void visitBlockCardBody() {
-        blockLog.stayBlock('visitBlockCardBody')
+        blockLog.logStayBlock('visitBlockCardBody')
         blockLog.topElement = block.cardBody(cardDivElement)
     }
 
     @Override
     void visitBlockCardEnd() {
-        exitBlock('visitBlockCardEnd')
+        logExitBlock('visitBlockCardEnd')
         cardHeaderElement = null
         cardDivElement = null
-        blockLog.topElement = blockLog.topElement.toParentTaackTag(TaackTag.CARD)
+        blockLog.restorePosition()
     }
 
     // --- ScrollPanel ---
 
     @Override
     void visitBlockScrollPanel(String maxHeight) {
-        enterBlock('visitBlockScrollPanel')
+        logEnterBlock('visitBlockScrollPanel')
+        blockLog.savePosition()
         blockLog.topElement.setTaackTag(TaackTag.SCROLL_PANEL)
         blockLog.topElement = block.scrollPanel(blockLog.topElement, maxHeight)
     }
 
     @Override
     void visitBlockScrollPanelEnd() {
-        exitBlock('visitBlockScrollPanelEnd')
-        blockLog.topElement = blockLog.topElement.toParentTaackTag(TaackTag.SCROLL_PANEL)
+        logExitBlock('visitBlockScrollPanelEnd')
+        blockLog.restorePosition()
     }
 
     @Override

--- a/taack-ui/src/main/groovy/taack/ui/dump/RawHtmlDropdownMenuDump.groovy
+++ b/taack-ui/src/main/groovy/taack/ui/dump/RawHtmlDropdownMenuDump.groovy
@@ -28,12 +28,12 @@ class RawHtmlDropdownMenuDump implements IUiMenuVisitor {
         blockLog.topElement.setTaackTag(TaackTag.MENU_BLOCK)
     }
 
-    void enterBlock(String toPrint) {
-        blockLog.enterBlock(RawHtmlDropdownMenuDump.simpleName + '::' + toPrint)
+    void logEnterBlock(String toPrint) {
+        blockLog.logEnterBlock(RawHtmlDropdownMenuDump.simpleName + '::' + toPrint)
     }
 
-    void exitBlock(String toPrint) {
-        blockLog.exitBlock(RawHtmlDropdownMenuDump.simpleName + '::' + toPrint)
+    void logExitBlock(String toPrint) {
+        blockLog.logExitBlock(RawHtmlDropdownMenuDump.simpleName + '::' + toPrint)
     }
 
     @Override
@@ -46,7 +46,8 @@ class RawHtmlDropdownMenuDump implements IUiMenuVisitor {
 
     @Override
     void visitMenuStart(MenuSpec.MenuMode menuMode, String ajaxBlockId) {
-        enterBlock('visitMenuStart futurCurrentAjaxBlockId: ' + ajaxBlockId)
+        logEnterBlock('visitMenuStart futurCurrentAjaxBlockId: ' + ajaxBlockId)
+        blockLog.savePosition()
         futurCurrentAjaxBlockId = ajaxBlockId
         blockLog.topElement.setTaackTag(TaackTag.MENU_CONTEXTUAL)
         menu = new DropdownMenu(parameter.target == Parameter.RenderingTarget.MAIL, blockLog)
@@ -55,14 +56,14 @@ class RawHtmlDropdownMenuDump implements IUiMenuVisitor {
 
     @Override
     void visitMenuStartEnd() {
-        exitBlock('visitMenuStartEnd')
+        logExitBlock('visitMenuStartEnd')
         futurCurrentAjaxBlockId = null
-        blockLog.topElement = blockLog.topElement.toParentTaackTag(TaackTag.MENU_CONTEXTUAL)
+        blockLog.restorePosition()
     }
 
     @Override
     void visitMenu(String controller, String action, Map<String, ?> params) {
-        blockLog.stayBlock('visitMenu')
+        blockLog.logStayBlock('visitMenu')
         visitLabeledSubMenu(null, controller, action, params)
     }
 
@@ -75,7 +76,7 @@ class RawHtmlDropdownMenuDump implements IUiMenuVisitor {
     void visitLabeledSubMenu(String i18n, String controller, String action, Map<String, ?> params) {
         i18n ?= parameter.trField(controller, action, params?.containsKey('id'))
 
-        blockLog.stayBlock('visitLabeledSubContextualMenu ' + i18n)
+        blockLog.logStayBlock('visitLabeledSubContextualMenu ' + i18n)
         Map cp = parameter.params
         if (params) {
             if (cp.containsKey('lang') && !params.containsKey('lang')) cp.remove('lang')
@@ -106,7 +107,7 @@ class RawHtmlDropdownMenuDump implements IUiMenuVisitor {
     @Override
     void visitSubMenuIcon(String i18n, ActionIcon actionIcon, String controller, String action, Map<String, ?> params, boolean isModal) {
         i18n ?= parameter.trField(controller, action, params?.containsKey('id'))
-        blockLog.stayBlock('visitSubMenuIcon ' + i18n)
+        blockLog.logStayBlock('visitSubMenuIcon ' + i18n)
 
         if (parameter.target != Parameter.RenderingTarget.MAIL)
             menu.menuIcon(blockLog.topElement, actionIcon.getHtml(i18n, 24), parameter.urlMapped(controller, action, params, isModal), isModal)

--- a/taack-ui/src/main/groovy/taack/ui/dump/RawHtmlFormDump.groovy
+++ b/taack-ui/src/main/groovy/taack/ui/dump/RawHtmlFormDump.groovy
@@ -72,6 +72,7 @@ final class RawHtmlFormDump implements IUiFormVisitor {
         this.lockedFields = lockedFields
         this.aObject = aObject
         String id = aObject.hasProperty(ST_ID) ? (aObject[ST_ID] != null ? aObject[ST_ID] : '') : ''
+        blockLog.savePosition()
         blockLog.topElement.setTaackTag(TaackTag.FORM)
         blockLog.topElement.builder.addChildren(
                 formThemed.builder.addClasses('taackForm').addChildren(
@@ -92,11 +93,12 @@ final class RawHtmlFormDump implements IUiFormVisitor {
             formThemed.addFormAction(blockLog.topElement, it.cValue, it.aValue, it.bValue)
         }
 
-        blockLog.topElement = blockLog.topElement.toParentTaackTag(TaackTag.FORM)
+        blockLog.restorePosition()
     }
 
     @Override
     void visitFormSection(String i18n, boolean initiallyCollapsed) {
+        blockLog.savePosition()
         uncollapseSection = false
 
         i18n ?= parameter.trField(parameter.controllerName, parameter.actionName, false)
@@ -107,7 +109,7 @@ final class RawHtmlFormDump implements IUiFormVisitor {
     void visitFormSectionEnd() {
         uncollapseSection = false
 
-        blockLog.topElement = blockLog.topElement.toParentTaackTag(TaackTag.SECTION).parent
+        blockLog.restorePosition()
     }
 
     @Override
@@ -206,6 +208,7 @@ final class RawHtmlFormDump implements IUiFormVisitor {
 
     @Override
     void visitFormTabs(List<String> names, Width width = Width.QUARTER) {
+        blockLog.savePosition()
         blockLog.topElement.setTaackTag(TaackTag.TABS)
         blockLog.topElement = layout.tabs(blockLog.topElement, names)
         tabOccurrence = 0
@@ -213,19 +216,20 @@ final class RawHtmlFormDump implements IUiFormVisitor {
 
     @Override
     void visitFormTabsEnd() {
-        blockLog.topElement = blockLog.topElement.toParentTaackTag(TaackTag.TABS)
+        blockLog.restorePosition()
         layout.setTabIdAndCounter(layout.tabIds + 1)
     }
 
     @Override
     void visitFormTab(String name) {
+        blockLog.savePosition()
         blockLog.topElement.setTaackTag(TaackTag.TAB)
         blockLog.topElement = layout.tab(blockLog.topElement, tabOccurrence++)
     }
 
     @Override
     void visitFormTabEnd() {
-        blockLog.topElement = blockLog.topElement.toParentTaackTag(TaackTag.TAB)
+        blockLog.restorePosition()
     }
 
     @Override
@@ -309,35 +313,38 @@ final class RawHtmlFormDump implements IUiFormVisitor {
 
     @Override
     void visitCol(Width width) {
+        blockLog.savePosition()
         blockLog.topElement.setTaackTag(TaackTag.COL)
         blockLog.topElement = layout.col(blockLog.topElement, width)
     }
 
     @Override
     void visitColEnd() {
-        blockLog.topElement = blockLog.topElement.toParentTaackTag(TaackTag.COL)
+        blockLog.restorePosition()
     }
 
     @Override
     void visitRow() {
+        blockLog.savePosition()
         blockLog.topElement.setTaackTag(TaackTag.ROW)
         blockLog.topElement = layout.row(blockLog.topElement)
     }
 
     @Override
     void visitRowEnd() {
-        blockLog.topElement = blockLog.topElement.toParentTaackTag(TaackTag.ROW)
+        blockLog.restorePosition()
     }
 
     @Override
     void visitRowCols(int cols) {
+        blockLog.savePosition()
         blockLog.topElement.setTaackTag(TaackTag.ROW)
         blockLog.topElement = layout.rowCols(blockLog.topElement, cols)
     }
 
     @Override
     void visitRowColsEnd() {
-        blockLog.topElement = blockLog.topElement.toParentTaackTag(TaackTag.ROW)
+        blockLog.restorePosition()
     }
 
     @Override

--- a/taack-ui/src/main/groovy/taack/ui/dump/RawHtmlKanbanDump.groovy
+++ b/taack-ui/src/main/groovy/taack/ui/dump/RawHtmlKanbanDump.groovy
@@ -42,7 +42,8 @@ final class RawHtmlKanbanDump implements IUiKanbanVisitor {
 
     @Override
     void visitKanban() {
-        blockLog.enterBlock('visitKanban')
+        blockLog.logEnterBlock('visitKanban')
+        blockLog.savePosition()
         blockLog.topElement.setTaackTag(TaackTag.KANBAN)
         HTMLDiv kanbanDiv = new HTMLDiv().builder.addClasses('row gx-2').putAttribute('taackKanbanId', blockId).build() as HTMLDiv
         blockLog.topElement.builder.addChildren(kanbanDiv)
@@ -51,19 +52,18 @@ final class RawHtmlKanbanDump implements IUiKanbanVisitor {
 
     @Override
     void visitKanbanEnd() {
-        blockLog.exitBlock('visitKanbanEnd')
+        blockLog.logExitBlock('visitKanbanEnd')
         initialForm.builder.addChildren(mapAdditionalHiddenParams.values() as IHTMLElement[])
-        blockLog.topElement = blockLog.topElement.toParentTaackTag(TaackTag.KANBAN)
+        blockLog.restorePosition()
     }
 
     @Override
     void visitKanbanWithoutFilter() {
-        blockLog.enterBlock('visitKanban')
+        blockLog.logEnterBlock('visitKanban')
         HTMLDiv kanbanDiv = new HTMLDiv().builder.addClasses('row gx-2').setTaackTag(TaackTag.KANBAN).putAttribute('taackKanbanId', blockId).build() as HTMLDiv
         blockLog.topElement.builder.addChildren(kanbanDiv)
         blockLog.topElement = kanbanDiv
-
-//        List<HTMLInput> inputList = []
+        blockLog.savePosition()
 
         parameter.paramsToKeep.each {
             if (it.value instanceof Collection || it.value instanceof String[]) {
@@ -92,7 +92,8 @@ final class RawHtmlKanbanDump implements IUiKanbanVisitor {
 
     @Override
     void visitColumn(MethodClosure action, Map<String, ? extends Object> params) {
-        blockLog.enterBlock('visitColumn')
+        blockLog.logEnterBlock('visitColumn')
+        blockLog.savePosition()
         HTMLDiv columnDiv = new HTMLDiv().builder.addClasses('kanban-column col m-2')
                 .putAttribute('taackDropAction', action ? parameter.urlMapped(Utils.getControllerName(action), action.method.toString(), params) : null)
                 .setTaackTag(TaackTag.KANBAN_COL).build() as HTMLDiv
@@ -102,8 +103,8 @@ final class RawHtmlKanbanDump implements IUiKanbanVisitor {
 
     @Override
     void visitColumnEnd() {
-        blockLog.exitBlock('visitColumnEnd')
-        blockLog.topElement = blockLog.topElement.toParentTaackTag(TaackTag.KANBAN_COL).parent
+        blockLog.logExitBlock('visitColumnEnd')
+        blockLog.restorePosition()
     }
 
     @Override
@@ -116,7 +117,8 @@ final class RawHtmlKanbanDump implements IUiKanbanVisitor {
 
     @Override
     void visitCard(GormEntity gorm, MethodClosure action, Map<String, ? extends Object> params) {
-        blockLog.enterBlock('visitCard')
+        blockLog.logEnterBlock('visitCard')
+        blockLog.savePosition()
         HTMLSpan cardSpan = new HTMLSpan().builder.addClasses('kanban-card').setTaackTag(TaackTag.KANBAN_CARD)
                 .putAttribute('taackDbClickAction', action ? parameter.urlMapped(Utils.getControllerName(action), action.method.toString(), params) : null)
                 .putAttribute('cardId', gorm ? gorm.ident().toString() : '')
@@ -128,8 +130,8 @@ final class RawHtmlKanbanDump implements IUiKanbanVisitor {
 
     @Override
     void visitCardEnd() {
-        blockLog.exitBlock('visitCardEnd')
-        blockLog.topElement = blockLog.topElement.toParentTaackTag(TaackTag.KANBAN_CARD).parent
+        blockLog.logExitBlock('visitCardEnd')
+        blockLog.restorePosition()
     }
 
     @Override

--- a/taack-ui/src/main/groovy/taack/ui/dump/RawHtmlTableDump.groovy
+++ b/taack-ui/src/main/groovy/taack/ui/dump/RawHtmlTableDump.groovy
@@ -35,6 +35,9 @@ import static taack.render.TaackUiService.tr
 @CompileStatic
 final class RawHtmlTableDump implements IUiTableVisitor {
 
+    private static final Style DISPLAY_BLOCK_STYLE = new Style(null, 'display: block;')
+    private static final DisplayBlock DISPLAY_BLOCK_DESCRIPTOR = new DisplayBlock()
+
     final String blockId
     final Parameter parameter
     final ThemableTable themableTable
@@ -91,10 +94,7 @@ final class RawHtmlTableDump implements IUiTableVisitor {
     }
 
     static final IHTMLElement displayCell(final String cell, final Style style, final String url) {
-        Style displayBlock = new Style(null, 'display: block;')
-        if (cell && style) {
-            displayBlock += style
-        }
+        Style displayBlock = (cell && style) ? DISPLAY_BLOCK_STYLE + style : DISPLAY_BLOCK_STYLE
         HTMLTxtContent cellHTML = new HTMLTxtContent(cell ?: '<br/>')
         if (!url) {
             HTMLSpan speedSpan = new HTMLSpan()
@@ -132,8 +132,8 @@ final class RawHtmlTableDump implements IUiTableVisitor {
     @Override
     void visitTableEnd() {
         initialForm.builder.addChildren(mapAdditionalHiddenParams.values() as IHTMLElement[])
-        blockLog.exitBlock('visitTableEnd')
-        blockLog.topElement = blockLog.topElement.toParentTaackTag(TaackTag.TABLE)
+        blockLog.logExitBlock('visitTableEnd')
+        blockLog.restorePosition()
 
         if (initialSortingOrder) {
             blockLog.topElement.children[0].getBuilder().putAttribute('initialSortField', initialSortingOrder.aValue)
@@ -142,7 +142,8 @@ final class RawHtmlTableDump implements IUiTableVisitor {
 
     @Override
     void visitColumn(Integer colSpan, Integer rowSpan) {
-        blockLog.enterBlock('visitColumn')
+        blockLog.logEnterBlock('visitColumn')
+        blockLog.savePosition()
         colCount++
         isInCol = true
         if (isInHeader) {
@@ -160,7 +161,8 @@ final class RawHtmlTableDump implements IUiTableVisitor {
 
     @Override
     void visitHeader() {
-        blockLog.enterBlock('visitHeader')
+        blockLog.logEnterBlock('visitHeader')
+        blockLog.savePosition()
         isInHeader = true
         HTMLTr tr = new HTMLTr()
         tr.addClasses('align-middle')
@@ -174,9 +176,9 @@ final class RawHtmlTableDump implements IUiTableVisitor {
 
     @Override
     void visitHeaderEnd() {
-        blockLog.exitBlock('visitHeaderEnd')
+        blockLog.logExitBlock('visitHeaderEnd')
         isInHeader = false
-        blockLog.topElement = blockLog.topElement.toParentTaackTag(TaackTag.TABLE_HEAD).parent
+        blockLog.restorePosition()
         HTMLTBody tb = new HTMLTBody().builder.setTaackTag(TaackTag.TABLE_HEAD).build() as HTMLTBody
         blockLog.topElement.builder.addChildren(tb)
         blockLog.topElement = tb
@@ -184,14 +186,15 @@ final class RawHtmlTableDump implements IUiTableVisitor {
 
     @Override
     void visitColumnEnd() {
-        blockLog.exitBlock('visitColumnEnd')
+        blockLog.logExitBlock('visitColumnEnd')
         isInCol = false
-        blockLog.topElement = blockLog.topElement.toParentTaackTag(TaackTag.TABLE_COL).parent
+        blockLog.restorePosition()
     }
 
     @Override
     void visitRow(Style style, boolean hasChildren) {
-        blockLog.enterBlock('visitRow')
+        blockLog.logEnterBlock('visitRow')
+        blockLog.savePosition()
         rowStyle = style
         stripped++
         HTMLTr tr = new HTMLTr()
@@ -215,21 +218,21 @@ final class RawHtmlTableDump implements IUiTableVisitor {
 
     @Override
     void visitRowEnd() {
-        blockLog.exitBlock('visitRowEnd')
+        blockLog.logExitBlock('visitRowEnd')
         rowStyle = null
-        blockLog.topElement = blockLog.topElement.toParentTaackTag(TaackTag.TABLE_ROW).parent
+        blockLog.restorePosition()
     }
 
     @Override
     void visitRowIndent(Boolean isExpended = false) {
-        blockLog.enterBlock('visitRowIndent')
+        blockLog.logEnterBlock('visitRowIndent')
         indent++
         rowIndentIsExpended[indent] = rowIndentIsExpended[indent - 1] == false ? false : isExpended
     }
 
     @Override
     void visitRowIndentEnd() {
-        blockLog.exitBlock('visitRowIndentEnd')
+        blockLog.logExitBlock('visitRowIndentEnd')
         indent--
     }
 
@@ -261,7 +264,8 @@ final class RawHtmlTableDump implements IUiTableVisitor {
 
     @Override
     void visitRowColumn(Integer colSpan, Integer rowSpan, Style style) {
-        blockLog.enterBlock('visitRowColumn')
+        blockLog.logEnterBlock('visitRowColumn')
+        blockLog.savePosition()
         isInCol = true
         IHTMLElement.HTMLElementBuilder tdBuilder = new HTMLTd(colSpan, rowSpan).builder
         if (style?.cssClassesString) tdBuilder.addClasses(style.cssClassesString)
@@ -282,21 +286,23 @@ final class RawHtmlTableDump implements IUiTableVisitor {
     @Override
     void visitRowColumnEnd() {
         this.cellOption = null
-        blockLog.exitBlock('visitRowColumnEnd')
+        blockLog.logExitBlock('visitRowColumnEnd')
         isInCol = false
-        blockLog.topElement = blockLog.topElement.toParentTaackTag(TaackTag.TABLE_COL).parent
+        blockLog.restorePosition()
     }
 
     @Override
     void visitTable() {
-        blockLog.enterBlock('visitTable')
+        blockLog.logEnterBlock('visitTable')
+        blockLog.savePosition()
         blockLog.topElement.setTaackTag(TaackTag.TABLE)
         blockLog.topElement = themableTable.table(blockLog.topElement, blockId, tableOption)
     }
 
     @Override
     void visitTableWithoutFilter() {
-        blockLog.enterBlock('visitTableWithoutFilter')
+        blockLog.logEnterBlock('visitTableWithoutFilter')
+        blockLog.savePosition()
         IHTMLElement table = themableTable.table(blockLog.topElement, blockId, tableOption)
         blockLog.topElement.setTaackTag(TaackTag.TABLE)
 
@@ -334,7 +340,7 @@ final class RawHtmlTableDump implements IUiTableVisitor {
         boolean addColumn = !isInCol
         if (addColumn) visitColumn(null, null)
         blockLog.topElement.builder.addChildren(
-                new HTMLSpan().builder.addClasses('sortColumn').setStyle(new DisplayBlock()).putAttribute('sortField', RawHtmlFilterDump.getQualifiedName(fields)).addChildren(
+                new HTMLSpan().builder.addClasses('sortColumn').setStyle(DISPLAY_BLOCK_DESCRIPTOR).putAttribute('sortField', RawHtmlFilterDump.getQualifiedName(fields)).addChildren(
                         new HTMLTxtContent(i18n)
                 ).build()
         )
@@ -347,7 +353,7 @@ final class RawHtmlTableDump implements IUiTableVisitor {
         boolean addColumn = !isInCol
         if (addColumn) visitColumn(null, null)
         blockLog.topElement.builder.addChildren(
-                new HTMLSpan().builder.setStyle(new DisplayBlock()).addChildren(
+                new HTMLSpan().builder.setStyle(DISPLAY_BLOCK_DESCRIPTOR).addChildren(
                         new HTMLTxtContent("${i18n}")
                 ).build()
         )
@@ -484,7 +490,8 @@ final class RawHtmlTableDump implements IUiTableVisitor {
 
     @Override
     void visitColumnSelect(String paramsKey) {
-        blockLog.enterBlock('visitColumnSelect')
+        blockLog.logEnterBlock('visitColumnSelect')
+        blockLog.savePosition()
         isInCol = true
         selectColumnParamsKey = paramsKey ?: 'selectedItems'
         BootstrapForm f = new BootstrapForm(blockLog).builder.addChildren(
@@ -533,9 +540,9 @@ final class RawHtmlTableDump implements IUiTableVisitor {
 
     @Override
     void visitColumnSelectEnd() {
-        blockLog.exitBlock('visitColumnSelectEnd')
+        blockLog.logExitBlock('visitColumnSelectEnd')
         isInCol = false
-        blockLog.topElement = blockLog.topElement.toParentTaackTag(TaackTag.TABLE_COL).parent
+        blockLog.restorePosition()
     }
 
     @Override
@@ -620,7 +627,7 @@ final class RawHtmlTableDump implements IUiTableVisitor {
 
     @Override
     void visitRowQuickEdit(Long id, MethodClosure apply) {
-        blockLog.enterBlock('visitRowQuickEdit')
+        blockLog.logEnterBlock('visitRowQuickEdit')
         HTMLForm f = new HTMLForm(parameter.urlMapped(apply, [id: id, isAjax: true])).builder.addClasses('taackTableInlineForm').addChildren(
                 new HTMLInput(InputType.HIDDEN, parameter.applicationTagLib.controllerName, 'originController'),
                 new HTMLInput(InputType.HIDDEN, parameter.applicationTagLib.actionName, 'originAction'),
@@ -636,7 +643,7 @@ final class RawHtmlTableDump implements IUiTableVisitor {
 
     @Override
     void visitRowQuickEditEnd() {
-        blockLog.exitBlock('visitRowQuickEditEnd')
+        blockLog.logExitBlock('visitRowQuickEditEnd')
 //        blockLog.topElement = blockLog.topElement.toParentTaackTag(TaackTag.TABLE_QUICK_EDIT).parent
         HTMLInput b = HTMLInput.inputSubmit('s', 'form' + formId)
         quickEditSubmitPlace.addChildren(b)

--- a/taack-ui/src/main/groovy/taack/ui/dump/RenderDecision.groovy
+++ b/taack-ui/src/main/groovy/taack/ui/dump/RenderDecision.groovy
@@ -1,0 +1,85 @@
+package taack.ui.dump
+
+import groovy.transform.CompileStatic
+import taack.ui.dump.common.BlockLog
+
+@CompileStatic
+final class RenderDecision {
+    private final Parameter parameter
+    private final BlockLog blockLog
+
+    boolean isModal = false
+    boolean isRefreshing
+    boolean renderTab = false
+    boolean poke = false
+    String currentAjaxBlockId = null
+    String explicitAjaxBlockId = null
+
+    RenderDecision(Parameter parameter, BlockLog blockLog) {
+        this.parameter = parameter
+        this.blockLog = blockLog
+        this.isRefreshing = parameter.params.boolean('refresh')
+    }
+
+    private void simpleLog(String toPrint) {
+        blockLog.simpleLog('RenderDecision::' + toPrint)
+    }
+
+    /**
+    * Check if a block DSL element has to be rendered. If a page contains multiple block, and user click on
+    * a table to sort, only the table will be rendered when processing the DSL.
+    *
+    * * If the page is not ajax, everything is rendered
+    * * else
+    * * * If no explicit ajaxBlock, only current or target ajaxBlock is rendered
+    * * * If explicit ajaxBlocks are specified (via {@link #setExplicitAjaxBlockId(String id) setAjaxBlockId}),
+    *     only then will be rendered if in ajax mode (parameter.isAjaxRendering == true)
+    *
+    * @param id
+    * @return
+    */
+    boolean shouldRender(String id = null) {
+        // if many blocks in the same response, only redraw current block
+        // further the first block must be in ajaxMode until current block ends
+        if (parameter.target == Parameter.RenderingTarget.MAIL) return true
+        if (poke) return true
+        simpleLog("shouldRender0 :> renderTab: $renderTab, id: $id, explicitAjaxBlockId: ${explicitAjaxBlockId}, isModal: ${isModal}, params: ${parameter.params}")
+
+        if (!parameter.isAjaxRendering) {
+            simpleLog('shouldRender01: true')
+            return true
+        }
+        if (renderTab && parameter.isAjaxRendering) {
+            simpleLog('shouldRender02: true')
+            return true
+        }
+
+        if ((!id && (!parameter.isAjaxRendering && !isModal) || explicitAjaxBlockId != null)) {
+            boolean ret = !parameter.tabId && !parameter.ajaxBlockId || parameter.ajaxBlockId == explicitAjaxBlockId
+            simpleLog("shouldRender1 return ${ret}, because NOT (AJAX OR MODAL) OR AJAX BUT ANOTHER id")
+            return ret
+        } else if (!id && !parameter.ajaxBlockId) {
+            simpleLog("shouldRender2 return isModal($isModal && $poke)")
+            return isModal
+        }
+
+        if (parameter.isAjaxRendering && currentAjaxBlockId == null) {
+            currentAjaxBlockId = parameter.ajaxBlockId
+        }
+
+        if (parameter.targetAjaxBlockId) {
+            currentAjaxBlockId = parameter.targetAjaxBlockId
+        }
+
+        simpleLog("shouldRender3 :> currentAjaxBlockId = ${currentAjaxBlockId}, targetAjaxBlockId = ${parameter.targetAjaxBlockId}, ajaxBlockId = ${parameter.ajaxBlockId}")
+
+        boolean doRender = (currentAjaxBlockId == id && (isModal || isRefreshing)) || (!currentAjaxBlockId && isModal)
+        simpleLog("shouldRender4 => doRender = $doRender && $poke")
+        return doRender
+    }
+
+    boolean shouldRenderLayout() {
+        simpleLog("shouldRenderLayout ${parameter.isAjaxRendering}, ${parameter.ajaxBlockId} $currentAjaxBlockId ${parameter.targetAjaxBlockId}")
+        return !parameter.isAjaxRendering
+    }
+}

--- a/taack-ui/src/main/groovy/taack/ui/dump/common/BlockLog.groovy
+++ b/taack-ui/src/main/groovy/taack/ui/dump/common/BlockLog.groovy
@@ -1,8 +1,10 @@
 package taack.ui.dump.common
 
+import groovy.transform.CompileStatic
 import taack.ui.dump.html.element.IHTMLElement
 import taack.ui.dump.html.theme.ThemeSelector
 
+@CompileStatic
 final class BlockLog {
     private final String indent = '   '
     private int occ = 0
@@ -10,18 +12,24 @@ final class BlockLog {
     IHTMLElement topElement
     final ThemeSelector ts
 
+    private final Deque<IHTMLElement> positionStack = new ArrayDeque<>()
+
+    void savePosition() { positionStack.push(topElement) }
+    IHTMLElement peekPosition() { positionStack.peek() }
+    void restorePosition() { topElement = positionStack.pop() }
+
     BlockLog(final ThemeSelector ts) {
         this.ts = ts
     }
 
-    void enterBlock(String method) {
+    void logEnterBlock(String method) {
         if (debug) {
             if (occ < 0) println "OCC < 0 !!! occ == $occ " + method + ' +++ ' + topElement
             else println(indent*occ++ + method + ' +++ ' + topElement)
         }
     }
 
-    void stayBlock(String method) {
+    void logStayBlock(String method) {
         if (debug) {
             if (occ < 0) println "OCC < 0 !!! occ == $occ " + method + ' === ' + topElement
             else println(indent*occ + method + ' === ' + topElement)
@@ -34,7 +42,7 @@ final class BlockLog {
         }
     }
 
-    void exitBlock(String method) {
+    void logExitBlock(String method) {
         if (debug) {
             if (occ < 0) {
                 println "OCC < 0 !!! occ == $occ " + method + ' --- ' + topElement

--- a/taack-ui/src/main/groovy/taack/ui/dump/html/element/IHTMLElement.groovy
+++ b/taack-ui/src/main/groovy/taack/ui/dump/html/element/IHTMLElement.groovy
@@ -37,6 +37,12 @@ enum TaackTag {
     KANBAN,
     KANBAN_COL,
     KANBAN_CARD
+
+    final String attrFragment
+
+    TaackTag() {
+        this.attrFragment = ' taackTag="' + this.name() + '"'
+    }
 }
 
 @CompileStatic
@@ -54,7 +60,7 @@ trait IHTMLElement {
 
     void putAttr(String key, String value) {
         if (attr.length() > 0) attr.append(' ')
-        attr.append(key).append('="').append(value ?: '').append('" ')
+        attr.append(key).append('="').append(value ?: '').append('"')
     }
 
     void resetClasses() {
@@ -128,20 +134,21 @@ trait IHTMLElement {
 
     void getOutput(OutputStream out) {
         if (tag) {
-            out << '\n<' + tag
-            if (taackTag) out << ' taackTag="' + taackTag.name() + '"'
-            if (id) out << ' id="' + id + '"'
-            if (classes.length() > 0) out << ' class="' + classes.toString() + '"'
-            if (attr.length() > 0) out << ' ' + attr.toString().trim()
-            out << '>'
+            StringBuilder sb = new StringBuilder(128)
+            sb.append('\n<').append(tag)
+            if (taackTag) sb.append(taackTag.attrFragment)
+            if (id) sb.append(' id="').append(id).append('"')
+            if (classes.length() > 0) sb.append(' class="').append(classes).append('"')
+            if (attr.length() > 0) sb.append(' ').append(attr)
+            sb.append('>')
+            out << sb
         }
 
         for (IHTMLElement c : children) {
             c.getOutput(out)
         }
 
-        if (tag)
-            out << '</' + tag + '>'
+        if (tag) out << '</' + tag + '>'
     }
 
     <T extends IHTMLElement> HTMLElementBuilder<T> getBuilder() {

--- a/taack-ui/src/main/groovy/taack/ui/dump/html/element/IHTMLElement.groovy
+++ b/taack-ui/src/main/groovy/taack/ui/dump/html/element/IHTMLElement.groovy
@@ -43,9 +43,9 @@ enum TaackTag {
 trait IHTMLElement {
     TaackTag taackTag
     String id
-    private String classes
-    private String attr
-    Vector<IHTMLElement> children = new Vector<>()
+    private StringBuilder classes = new StringBuilder()
+    private StringBuilder attr = new StringBuilder()
+    List<IHTMLElement> children = new ArrayList<>()
     IHTMLElement parent
 
     String getTag() {
@@ -53,17 +53,17 @@ trait IHTMLElement {
     }
 
     void putAttr(String key, String value) {
-        if (attr && !attr.empty) attr += ' ' + key + '="' + (value?:'') + '" '
-        else attr = key + '="' + (value?:'') + '" '
+        if (attr.length() > 0) attr.append(' ')
+        attr.append(key).append('="').append(value ?: '').append('" ')
     }
 
     void resetClasses() {
-        classes = ''
+        classes.setLength(0)
     }
 
     void putClass(String value) {
-        if (classes && !classes.empty) classes += ' ' + value
-        else classes = value
+        if (classes.length() > 0) classes.append(' ')
+        classes.append(value)
     }
 
     void setOnClick(IJavascriptDescriptor onc) {
@@ -113,7 +113,7 @@ trait IHTMLElement {
 
     @Override
     String toString() {
-        """IHTMLElement ${this.taackTag?.toString() + ':' + this.attr}"""
+        """IHTMLElement ${this.taackTag?.toString() + ':' + this.attr.toString()}"""
     }
 
     String indent() {
@@ -131,8 +131,8 @@ trait IHTMLElement {
             out << '\n<' + tag
             if (taackTag) out << ' taackTag="' + taackTag.name() + '"'
             if (id) out << ' id="' + id + '"'
-            if (classes) out << ' class="' + classes + '"'
-            if (attr) out << ' ' + attr.trim()
+            if (classes.length() > 0) out << ' class="' + classes.toString() + '"'
+            if (attr.length() > 0) out << ' ' + attr.toString().trim()
             out << '>'
         }
 

--- a/taack-ui/src/main/groovy/taack/ui/dump/html/menu/BootstrapMenu.groovy
+++ b/taack-ui/src/main/groovy/taack/ui/dump/html/menu/BootstrapMenu.groovy
@@ -20,7 +20,7 @@ final class BootstrapMenu implements IHTMLElement {
 
     IHTMLElement menuStart(IHTMLElement topElement = null) {
         IHTMLElement bootstrapMenu = this//new BootstrapMenu(themeMode, themeSize)
-        children.removeAllElements()
+        children.clear()
         topElement.addChildren(
                 bootstrapMenu.builder.addChildren(
                         new HTMLUl().builder.addClasses('navbar-nav', 'me-auto', 'mb-2', 'mb-lg-0').build()

--- a/taack-ui/src/main/groovy/taack/ui/dump/html/menu/DropdownMenu.groovy
+++ b/taack-ui/src/main/groovy/taack/ui/dump/html/menu/DropdownMenu.groovy
@@ -19,7 +19,7 @@ final class DropdownMenu implements IHTMLElement {
 
     IHTMLElement menuStart(IHTMLElement topElement = null) {
         IHTMLElement bootstrapMenu = this//new BootstrapMenu(themeMode, themeSize)
-        children.removeAllElements()
+        children.clear()
         topElement.addChildren(
                 bootstrapMenu.builder.addChildren(
                         new HTMLUl().builder.build()


### PR DESCRIPTION
## Description

Refactors the HTML rendering pipeline to improve performance and SoC. Slightly cleaner API for new feature development.
This should cause no breaking changes from what I've tested. 
Benchmarked with a 500 row table, after refreshing the pages multiple time until timing stabilizes to avoid JIT completely messing up the results.
<img width="1440" height="798" alt="image" src="https://github.com/user-attachments/assets/89efb9f3-cd96-4161-a279-b23ae57cbc20" />
_`visitBlock`-> `blockSpecifier.visitBlock(htmlBlock)` and `template` -> `htmlBlock.getOutput(...)`. Both in TaackUiService l. 156_

## Changes made

- New RenderDecision class to extract render attributes and logic (shouldRenderBlock, shouldRenderTab, shouldClose) out of RawHtmlBlockDump into a dedicated class with a clear responsibility
- Previous BlockLog manual oldParent replaced with tracking with a Deque (used as a stack), simplifying visit/visitEnd pairing and removing the coupling and the need to have identical TaackTag
- Vector -> ArrayList in `IHTMLElement`, the synchronisation from Vector wasn't needed
- StringBuilder for attribute/class accumulation. Replaces String repeated creation in some places (putAttr, getOuput, ...)
- Increased buffer size on BufferedOutputStream -> now uses the already existing bufferSize instead of hardcoded 4096
- New FormTabNameCollector to gathers tab names without executing inner form closures
- Renamed logging methods in BlockLog to clarify that they are logging methods (enterBlock -> logEnterBlock)
